### PR TITLE
Fix: Racy event validation in tests

### DIFF
--- a/tests/regression/tools/exclusion/test_exclusion
+++ b/tests/regression/tools/exclusion/test_exclusion
@@ -28,7 +28,7 @@ TESTAPP_NAME="gen-ust-nevents"
 TESTAPP_BIN="$TESTAPP_PATH/$TESTAPP_NAME/$TESTAPP_NAME"
 NR_ITER=100
 NR_USEC_WAIT=1
-NUM_TESTS=9
+NUM_TESTS=8
 
 source $TESTDIR/utils/utils.sh
 
@@ -44,15 +44,7 @@ function enable_ust_lttng_all_event_exclusion()
 
 function run_apps
 {
-	 $TESTAPP_BIN $NR_ITER $NR_USEC_WAIT >/dev/null 2>&1 &
-}
-
-function wait_apps
-{
-	while [ -n "$(pidof $BIN_NAME)" ]; do
-		sleep 1
-	done
-	pass "Wait for application end"
+	 $TESTAPP_BIN $NR_ITER $NR_USEC_WAIT >/dev/null 2>&1
 }
 
 function test_exclusion
@@ -67,7 +59,6 @@ function test_exclusion
 	# Trace apps
 	start_lttng_tracing $SESSION_NAME
 	run_apps
-	wait_apps
 	stop_lttng_tracing $SESSION_NAME
 
 	# Destroy session

--- a/tests/regression/tools/filtering/test_valid_filter
+++ b/tests/regression/tools/filtering/test_valid_filter
@@ -25,7 +25,7 @@ STATS_BIN="$TESTDIR/utils/babelstats.pl"
 SESSION_NAME="valid_filter"
 EVENT_NAME="tp:tptest"
 NR_ITER=100
-NUM_TESTS=338
+NUM_TESTS=290
 
 source $TESTDIR/utils/utils.sh
 
@@ -46,15 +46,7 @@ function enable_ust_lttng_event_filter()
 
 function run_apps
 {
-	./$CURDIR/$BIN_NAME $NR_ITER & >/dev/null 2>&1
-}
-
-function wait_apps
-{
-	while [ -n "$(pidof $BIN_NAME)" ]; do
-		sleep 1
-	done
-	pass "Wait for application end"
+	./$CURDIR/$BIN_NAME $NR_ITER >/dev/null 2>&1
 }
 
 function test_valid_filter
@@ -75,7 +67,6 @@ function test_valid_filter
 	# Trace apps
 	start_lttng_tracing $SESSION_NAME
 	run_apps
-	wait_apps
 	stop_lttng_tracing $SESSION_NAME
 
 	# Destroy session

--- a/tests/regression/tools/tracefile-limits/test_tracefile_count
+++ b/tests/regression/tools/tracefile-limits/test_tracefile_count
@@ -25,7 +25,7 @@ TESTAPP_NAME="gen-ust-events"
 TESTAPP_BIN="$TESTAPP_PATH/$TESTAPP_NAME/$TESTAPP_NAME"
 
 STATS_BIN="$TESTDIR/utils/babelstats.pl"
-NUM_TESTS=82
+NUM_TESTS=74
 
 NUM_CPUS=`nproc`
 
@@ -34,14 +34,6 @@ source $TESTDIR/utils/utils.sh
 if [ ! -x "$TESTAPP_BIN" ]; then
 	BAIL_OUT "No UST events binary detected."
 fi
-
-function wait_apps
-{
-	while [ -n "$(pidof $TESTAPP_NAME)" ]; do
-		sleep 0.5
-	done
-	pass "Wait for applications to end"
-}
 
 function enable_lttng_channel_count_limit ()
 {
@@ -126,9 +118,7 @@ function test_tracefile_count_limit ()
 
 	start_lttng_tracing $session_name
 
-	$TESTAPP_BIN $num_iter >/dev/null 2>&1 &
-
-	wait_apps
+	$TESTAPP_BIN $num_iter >/dev/null 2>&1
 
 	stop_lttng_tracing $session_name
 

--- a/tests/regression/tools/tracefile-limits/test_tracefile_size
+++ b/tests/regression/tools/tracefile-limits/test_tracefile_size
@@ -26,21 +26,13 @@ TESTAPP_PATH="$TESTDIR/utils/testapp"
 TESTAPP_NAME="gen-ust-events"
 TESTAPP_BIN="$TESTAPP_PATH/$TESTAPP_NAME/$TESTAPP_NAME"
 
-NUM_TESTS=47
+NUM_TESTS=42
 
 source $TESTDIR/utils/utils.sh
 
 if [ ! -x "$TESTAPP_BIN" ]; then
 	BAIL_OUT "No UST events binary detected."
 fi
-
-function wait_apps
-{
-	while [ -n "$(pidof $TESTAPP_NAME)" ]; do
-		sleep 0.5
-	done
-	pass "Wait for applications to end"
-}
 
 function enable_lttng_channel_size_limit ()
 {
@@ -118,9 +110,7 @@ function test_tracefile_size_limit ()
 
 	start_lttng_tracing $session_name
 
-	$TESTAPP_BIN $NR_ITER >/dev/null 2>&1 &
-
-	wait_apps
+	$TESTAPP_BIN $NR_ITER >/dev/null 2>&1
 
 	stop_lttng_tracing $session_name
 

--- a/tests/regression/ust/buffers-pid/test_buffers_pid
+++ b/tests/regression/ust/buffers-pid/test_buffers_pid
@@ -66,10 +66,9 @@ test_after_multiple_apps() {
 	start_lttng_tracing $SESSION_NAME
 
 	for i in `seq 1 5`; do
-		$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT & >/dev/null 2>&1
+		$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT >/dev/null 2>&1
 		ok $? "Start application $i for tracing"
 	done
-	wait_apps
 
 	stop_lttng_tracing $SESSION_NAME
 	destroy_lttng_session $SESSION_NAME


### PR DESCRIPTION
This pattern is fundamentally racy:

$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT >/dev/null 2>&1 &

[...]

while [ -n "$(pidof $TESTAPP_BIN)" ]; do
   sleep 1
done
pass "Wait for application end"

[...]

tracing_teardown

validate_trace $EXACT_EVENT_COUNT

It is possible that the check for "pidof $TESTAPP_BIN" occurs _before_
the execve() of the applications (starting the applications in background
with & is basically a clone() + execve()). The consequence is that the check
succeed, never waiting for any applications to finish and then the tracing
sessions are prematurely teared down. Thus the resulting trace contains only
some events. We then validate for a fixed number of events and thus the test
fails caused by this racy scheduling situation.

The fix is to start the applications in foreground instead of background.

Signed-off-by: Christian Babeux christian.babeux@efficios.com
