### PR TITLE
Fix: Tests with racy event validation

### DIFF
--- a/tests/regression/tools/live/test_lttng_ust
+++ b/tests/regression/tools/live/test_lttng_ust
@@ -78,11 +78,7 @@ start_lttng_relayd "-o $TRACE_PATH"
 setup_live_tracing
 
 # Run app in background
-$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT >/dev/null 2>&1 &
-# Wait for app to complete
-while [ -n "$(pidof $TESTAPP_NAME)" ]; do
-	sleep 0.5
-done
+$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT >/dev/null 2>&1
 
 clean_live_tracing
 

--- a/tests/regression/tools/live/test_ust
+++ b/tests/regression/tools/live/test_ust
@@ -81,11 +81,7 @@ fi
 setup_live_tracing
 
 # Run app in background
-$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT >/dev/null 2>&1 &
-# Wait for app to complete
-while [ -n "$(pidof $TESTAPP_NAME)" ]; do
-	sleep 0.5
-done
+$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT >/dev/null 2>&1
 
 # Start the live test
 $TESTDIR/regression/tools/live/live_test

--- a/tests/regression/tools/live/test_ust_tracefile_count
+++ b/tests/regression/tools/live/test_ust_tracefile_count
@@ -82,11 +82,7 @@ fi
 setup_live_tracing
 
 # Run app in background
-$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT >/dev/null 2>&1 &
-# Wait for app to complete
-while [ -n "$(pidof $TESTAPP_NAME)" ]; do
-	sleep 0.5
-done
+$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT >/dev/null 2>&1
 
 # Start the live test
 $TESTDIR/regression/tools/live/live_test

--- a/tests/regression/tools/streaming/test_ust
+++ b/tests/regression/tools/streaming/test_ust
@@ -29,7 +29,7 @@ PID_RELAYD=0
 
 TRACE_PATH=$(mktemp -d)
 
-NUM_TESTS=18
+NUM_TESTS=16
 
 source $TESTDIR/utils/utils.sh
 
@@ -44,13 +44,6 @@ function lttng_create_session_uri
 	ok $? "Create session with default path"
 }
 
-function wait_apps
-{
-	while [ -n "$(pidof $TESTAPP_NAME)" ]; do
-		sleep 0.5
-	done
-	pass "Wait for applications to end"
-}
 
 # MUST set TESTDIR before calling those functions
 
@@ -64,8 +57,8 @@ function test_ust_before_start ()
 	$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT >/dev/null 2>&1 &
 
 	start_lttng_tracing $SESSION_NAME
-
-	wait_apps
+	# Wait for the applications started in background
+	wait ${!}
 
 	stop_lttng_tracing $SESSION_NAME
 	destroy_lttng_session $SESSION_NAME
@@ -79,9 +72,7 @@ function test_ust_after_start ()
 	start_lttng_tracing $SESSION_NAME
 
 	# Run 5 times with a 1 second delay
-	$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT >/dev/null 2>&1 &
-
-	wait_apps
+	$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT >/dev/null 2>&1
 
 	stop_lttng_tracing $SESSION_NAME
 	destroy_lttng_session $SESSION_NAME

--- a/tests/regression/ust/before-after/test_before_after
+++ b/tests/regression/ust/before-after/test_before_after
@@ -25,7 +25,7 @@ TESTAPP_NAME="gen-ust-events"
 TESTAPP_BIN="$TESTAPP_PATH/$TESTAPP_NAME/$TESTAPP_NAME"
 SESSION_NAME="per-session"
 EVENT_NAME="tp:tptest"
-NUM_TESTS=17
+NUM_TESTS=16
 
 source $TESTDIR/utils/utils.sh
 
@@ -34,14 +34,6 @@ if [ ! -x "$TESTAPP_BIN" ]; then
 fi
 
 # MUST set TESTDIR before calling those functions
-
-function wait_app()
-{
-	while [ -n "$(pidof $TESTAPP_NAME)" ]; do
-		sleep 0.5
-	done
-	pass "Application $TESTAPP_NAME ended."
-}
 
 function test_before_apps()
 {
@@ -65,19 +57,15 @@ function test_after_apps()
 {
 	local out
 
+	create_lttng_session $SESSION_NAME $TRACE_PATH
+	enable_ust_lttng_event $SESSION_NAME $EVENT_NAME
+
 	$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT &
 	ok $? "Application started in background."
 
-	# BEFORE application is spawned
-	create_lttng_session $SESSION_NAME $TRACE_PATH
-	enable_ust_lttng_event $SESSION_NAME $EVENT_NAME
 	start_lttng_tracing $SESSION_NAME
 
-	# Since the start is done after the application is started, there is a
-	# bootstrap time needed between the session daemon and the UST tracer.
-	# Waiting for the application to end tells us when to stop everything and
-	# validate that at least one event is seen.
-	wait_app
+	wait ${!}
 
 	stop_lttng_tracing $SESSION_NAME
 	destroy_lttng_session $SESSION_NAME

--- a/tests/regression/ust/buffers-pid/test_buffers_pid
+++ b/tests/regression/ust/buffers-pid/test_buffers_pid
@@ -144,17 +144,18 @@ test_before_app() {
 
 	diag "Start application BEFORE tracing is started"
 
-	$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT &
-	ok $? "Start application to trace"
 
 	# BEFORE application is spawned
 	create_lttng_session $SESSION_NAME $TRACE_PATH
 	enable_channel_per_pid $SESSION_NAME "channel0"
 	enable_ust_lttng_event $SESSION_NAME $EVENT_NAME "channel0"
+
+	$TESTAPP_BIN $NR_ITER $NR_USEC_WAIT &
+	ok $? "Start application to trace"
+
 	start_lttng_tracing $SESSION_NAME
 
-	# At least hit one event
-	sleep 2
+	wait ${!}
 
 	stop_lttng_tracing $SESSION_NAME
 	destroy_lttng_session $SESSION_NAME
@@ -169,8 +170,6 @@ test_before_app() {
 		diag "Found $out event(s). Coherent."
 		out=0
 	fi
-
-	wait_apps
 
 	return $out
 }

--- a/tests/regression/ust/multi-session/test_multi_session
+++ b/tests/regression/ust/multi-session/test_multi_session
@@ -44,11 +44,7 @@ test_multi_session() {
 	./$CURDIR/gen-nevents $NR_ITER &
 	ok $? "Start application to generate $NR_ITER events"
 
-	# At least hit one event
-	while [ -n "$(pidof gen-nevents)" ]; do
-		sleep 0.1
-	done
-
+	wait ${!}
 	pass "Wait for events to record"
 
 	for i in `seq 0 3`; do


### PR DESCRIPTION
Similar to d7ee608c00feacea3cfd5a740df64e5215347cb9, make sure that
the event validation scheme is not racy. If we need to wait for applications
to complete simply start them in foreground or use the built-in 'wait'
command in bash to wait for applications started in background.

Signed-off-by: Christian Babeux christian.babeux@efficios.com
