### PR TITLE
Fix: incorrect script name in python logging test

### DIFF
--- a/tests/regression/ust/python-logging/Makefile.am
+++ b/tests/regression/ust/python-logging/Makefile.am
@@ -1,7 +1,7 @@
 #if USE_PYTHON
 
 noinst_SCRIPTS = test_python_logging
-EXTRA_DIST = test_python_logging LTTngTest.py
+EXTRA_DIST = test_python_logging test.py
 
 all-local:
 	@if [ x"$(srcdir)" != x"$(builddir)" ]; then \


### PR DESCRIPTION
Signed-off-by: Antoine Busque <abusque@efficios.com>