### PR TITLE
Fix: TimeoutExpired in Python tests not defined globally

### DIFF
--- a/tests/regression/ust/daemon/test_daemon.py
+++ b/tests/regression/ust/daemon/test_daemon.py
@@ -47,7 +47,7 @@ daemon_process = subprocess.Popen(test_path + "daemon", stdout=subprocess.PIPE)
 if sys.version_info >= (3, 3):
     try:
         daemon_process_return_code = daemon_process.wait(5)
-    except TimeoutExpired:
+    except subprocess.TimeoutExpired:
         daemon_process.kill()
         daemon_process_return_code = -1
 else:

--- a/tests/regression/ust/exit-fast/test_exit-fast.py
+++ b/tests/regression/ust/exit-fast/test_exit-fast.py
@@ -52,7 +52,7 @@ exit_fast_process = subprocess.Popen(test_path + "exit-fast", stdout=subprocess.
 if sys.version_info >= (3, 3):
     try:
         exit_fast_process.wait(5)
-    except TimeoutExpired:
+    except subprocess.TimeoutExpired:
         exit_fast_process.kill()
         bail("Failed to run exit-fast test application.")
 else:
@@ -66,7 +66,7 @@ exit_fast_process = subprocess.Popen([test_path + "exit-fast", "suicide"], stdou
 if sys.version_info >= (3, 3):
     try:
         exit_fast_process.wait(5)
-    except TimeoutExpired:
+    except subprocess.TimeoutExpired:
         exit_fast_process.kill()
         bail("Failed to run exit-fast test application in suicide mode.")
 else:

--- a/tests/regression/ust/fork/test_fork.py
+++ b/tests/regression/ust/fork/test_fork.py
@@ -47,7 +47,7 @@ fork_process = subprocess.Popen([test_path + "fork", test_path + "fork2"], stdou
 if sys.version_info >= (3, 3):
     try:
         fork_process.wait(5)
-    except TimeoutExpired:
+    except subprocess.TimeoutExpired:
         fork_process.kill()
         bail("Failed to run fork test application (time out)", session_info)
 else:

--- a/tests/regression/ust/libc-wrapper/test_libc-wrapper.py
+++ b/tests/regression/ust/libc-wrapper/test_libc-wrapper.py
@@ -46,7 +46,7 @@ malloc_process = subprocess.Popen(test_path + "prog", stdout=subprocess.PIPE, st
 if sys.version_info >= (3, 3):
     try:
         malloc_process.wait(5)
-    except TimeoutExpired:
+    except subprocess.TimeoutExpired:
         malloc_process.kill()
         bail("Failed to run libustinstr-malloc test application.", session_info)
 else:

--- a/tests/regression/ust/linking/test_linking.py
+++ b/tests/regression/ust/linking/test_linking.py
@@ -114,7 +114,7 @@ if DYNAMIC_TEST_ENABLED:
     if sys.version_info >= (3 ,3):
         try:
             demo_process.wait(5)
-        except TimeoutExpired:
+        except subprocess.TimeoutExpired:
             demo_process.kill()
             bail("Failed to run demo test application without preloading")
     else:
@@ -140,7 +140,7 @@ for executable in test_executables:
     if sys.version_info >= (3, 3):
         try:
             demo_process.wait(5)
-        except TimeoutExpired:
+        except subprocess.TimeoutExpired:
             demo_process.kill()
             bail("Failed to run {0} test application".format(executable_name))
     else:


### PR DESCRIPTION
The `TimeoutExpired` exception is used in multiple locations
throughout the Python tests. However, it needs to be used as
`subprocess.TimeoutExpired` given that it is only defined in that
module.

Signed-off-by: Antoine Busque <abusque@efficios.com>