### PR TITLE
Fix: set GLOBAL buffer type for kernel domain in list

### DIFF
--- a/src/bin/lttng-sessiond/cmd.c
+++ b/src/bin/lttng-sessiond/cmd.c
@@ -2457,6 +2457,10 @@ ssize_t cmd_list_domains(struct ltt_session *session,
 
 	if (session->kernel_session != NULL) {
 		(*domains)[index].type = LTTNG_DOMAIN_KERNEL;
+
+		/* Kernel session buffer type is always GLOBAL */
+		(*domains)[index].buf_type = LTTNG_BUFFER_GLOBAL;
+
 		index++;
 	}
 


### PR DESCRIPTION
See 71214b6.