### PR TITLE
Fix: MI: close domain when listing multiple agent domains

### DIFF
--- a/src/bin/lttng/commands/list.c
+++ b/src/bin/lttng/commands/list.c
@@ -1845,7 +1845,8 @@ int cmd_list(int argc, const char **argv)
 					if (ret) {
 						goto end;
 					}
-					continue;
+
+					goto next_domain;
 				}
 
 				switch (domains[i].type) {
@@ -1865,6 +1866,7 @@ int cmd_list(int argc, const char **argv)
 					goto end;
 				}
 
+next_domain:
 				if (lttng_opt_mi) {
 					/* Close domain element */
 					ret = mi_lttng_writer_close_element(writer);


### PR DESCRIPTION
Without this patch, each agent domain gets nested under
the previous one.