### PR TITLE
Fix event exclusion names

### DIFF
--- a/src/bin/lttng-sessiond/save.c
+++ b/src/bin/lttng-sessiond/save.c
@@ -661,7 +661,7 @@ int save_ust_event(struct config_writer *writer,
 		for (i = 0; i < event->exclusion->count; i++) {
 			ret = config_writer_write_element_string(writer,
 				config_element_exclusion,
-				&event->exclusion->names[0][i]);
+				&event->exclusion->names[i][0]);
 			if (ret) {
 				ret = LTTNG_ERR_SAVE_IO_FAIL;
 				goto end;

--- a/src/bin/lttng-sessiond/save.c
+++ b/src/bin/lttng-sessiond/save.c
@@ -661,7 +661,8 @@ int save_ust_event(struct config_writer *writer,
 		for (i = 0; i < event->exclusion->count; i++) {
 			ret = config_writer_write_element_string(writer,
 				config_element_exclusion,
-				&event->exclusion->names[i][0]);
+				LTTNG_EVENT_EXCLUSION_NAME_AT(
+					event->exclusion, i));
 			if (ret) {
 				ret = LTTNG_ERR_SAVE_IO_FAIL;
 				goto end;

--- a/src/bin/lttng-sessiond/trace-ust.c
+++ b/src/bin/lttng-sessiond/trace-ust.c
@@ -144,8 +144,7 @@ int trace_ust_ht_match_event(struct cds_lfht_node *node, const void *_key)
 					LTTNG_EVENT_EXCLUSION_NAME_AT(
 						key->exclusion, j);
 
-				if (!memcmp(name_ev, name_key,
-						LTTNG_SYMBOL_NAME_LEN)) {
+				if (!strcmp(name_ev, name_key)) {
 					/* Names match! */
 					found = 1;
 					break;
@@ -421,7 +420,7 @@ static int validate_exclusion(struct lttng_event_exclusion *exclusion)
 			const char *name_b =
 				LTTNG_EVENT_EXCLUSION_NAME_AT(exclusion, j);
 
-			if (!memcmp(name_a, name_b, LTTNG_SYMBOL_NAME_LEN)) {
+			if (!strcmp(name_a, name_b)) {
 				/* Match! */
 				ret = -1;
 				goto end;

--- a/src/bin/lttng-sessiond/trace-ust.c
+++ b/src/bin/lttng-sessiond/trace-ust.c
@@ -120,11 +120,45 @@ int trace_ust_ht_match_event(struct cds_lfht_node *node, const void *_key)
 	}
 
 	if (key->exclusion && event->exclusion) {
-		/* Both exclusions exist; check count followed by names. */
-		if (event->exclusion->count != key->exclusion->count ||
-				memcmp(event->exclusion->names, key->exclusion->names,
-					event->exclusion->count * LTTNG_SYMBOL_NAME_LEN) != 0) {
+		size_t i;
+
+		/* Check exclusion counts first. */
+		if (event->exclusion->count != key->exclusion->count) {
 			goto no_match;
+		}
+
+		/* Compare names invidually. */
+		for (i = 0; i < event->exclusion->count; ++i) {
+			size_t j;
+			int found = 0;
+			const char *name_ev =
+				LTTNG_EVENT_EXCLUSION_NAME_AT(
+					event->exclusion, i);
+
+			/*
+			 * Compare this exclusion name to all the key's
+			 * exclusion names.
+			 */
+			for (j = 0; j < key->exclusion->count; ++j) {
+				const char *name_key =
+					LTTNG_EVENT_EXCLUSION_NAME_AT(
+						key->exclusion, j);
+
+				if (!memcmp(name_ev, name_key,
+						LTTNG_SYMBOL_NAME_LEN)) {
+					/* Names match! */
+					found = 1;
+					break;
+				}
+			}
+
+			/*
+			 * If the current exclusion name was not found amongst
+			 * the key's exclusion names, then there's no match.
+			 */
+			if (!found) {
+				goto no_match;
+			}
 		}
 	}
 	/* Match. */

--- a/src/bin/lttng/commands/enable_events.c
+++ b/src/bin/lttng/commands/enable_events.c
@@ -677,6 +677,24 @@ end:
 	*exclusion_list_ptr = exclusion_list;
 	return ret;
 }
+
+static void warn_on_truncated_exclusion_names(char **exclusion_list,
+	int exclusion_count, int *warn)
+{
+	size_t i = 0;
+
+	for (i = 0; i < exclusion_count; ++i) {
+		const char *name = exclusion_list[i];
+		size_t len = strlen(name);
+
+		if (len >= LTTNG_SYMBOL_NAME_LEN) {
+			WARN("Event exclusion \"%s\" will be truncated",
+				name);
+			*warn = 1;
+		}
+	}
+}
+
 /*
  * Enabling event using the lttng API.
  * Note: in case of error only the last error code will be return.
@@ -796,6 +814,9 @@ static int enable_events(char *session_name)
 				goto error;
 			}
 			ev.exclusion = 1;
+
+			warn_on_truncated_exclusion_names(exclusion_list,
+				exclusion_count, &warn);
 		}
 		if (!opt_filter) {
 			ret = lttng_enable_event_with_exclusions(handle,
@@ -1088,6 +1109,9 @@ static int enable_events(char *session_name)
 				if (ret == CMD_ERROR) {
 					goto error;
 				}
+
+				warn_on_truncated_exclusion_names(
+					exclusion_list, exclusion_count, &warn);
 			}
 
 			ev.loglevel_type = opt_loglevel_type;

--- a/src/common/sessiond-comm/sessiond-comm.h
+++ b/src/common/sessiond-comm/sessiond-comm.h
@@ -334,7 +334,7 @@ struct lttng_filter_bytecode {
 struct lttng_event_exclusion {
 	uint32_t count;
 	char padding[LTTNG_EVENT_EXCLUSION_PADDING];
-	char names[LTTNG_SYMBOL_NAME_LEN][0];
+	char names[0][LTTNG_SYMBOL_NAME_LEN];
 } LTTNG_PACKED;
 
 /*

--- a/src/common/sessiond-comm/sessiond-comm.h
+++ b/src/common/sessiond-comm/sessiond-comm.h
@@ -337,6 +337,9 @@ struct lttng_event_exclusion {
 	char names[0][LTTNG_SYMBOL_NAME_LEN];
 } LTTNG_PACKED;
 
+#define LTTNG_EVENT_EXCLUSION_NAME_AT(_exclusion, _i) \
+	(&(_exclusion)->names[_i][0])
+
 /*
  * Data structure for the response from sessiond to the lttng client.
  */

--- a/src/common/sessiond-comm/sessiond-comm.h
+++ b/src/common/sessiond-comm/sessiond-comm.h
@@ -6,12 +6,12 @@
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License, version 2 only,
  * as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
  * more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/src/lib/lttng-ctl/lttng-ctl.c
+++ b/src/lib/lttng-ctl/lttng-ctl.c
@@ -1000,7 +1000,8 @@ int lttng_enable_event_with_exclusions(struct lttng_handle *handle,
 	/* Put exclusion names first in the data */
 	while (exclusion_count--) {
 		strncpy(varlen_data + LTTNG_SYMBOL_NAME_LEN * exclusion_count,
-			*(exclusion_list + exclusion_count), LTTNG_SYMBOL_NAME_LEN);
+			*(exclusion_list + exclusion_count),
+			LTTNG_SYMBOL_NAME_LEN - 1);
 	}
 	/* Add filter expression next */
 	if (lsm.u.enable.expression_len != 0) {

--- a/tests/unit/test_ust_data.c
+++ b/tests/unit/test_ust_data.c
@@ -39,7 +39,7 @@
 #define RANDOM_STRING_LEN	11
 
 /* Number of TAP tests in this file */
-#define NUM_TESTS 11
+#define NUM_TESTS 12
 
 /* For error.h */
 int lttng_opt_quiet = 1;
@@ -146,7 +146,9 @@ static void test_create_ust_event_exclusion(void)
 	struct ltt_ust_event *event;
 	struct lttng_event ev;
 	char *name;
+	char *random_name;
 	struct lttng_event_exclusion *exclusion;
+	const int exclusion_count = 2;
 
 	memset(&ev, 0, sizeof(ev));
 
@@ -159,26 +161,49 @@ static void test_create_ust_event_exclusion(void)
 	ev.loglevel_type = LTTNG_EVENT_LOGLEVEL_ALL;
 
 	/* set up an exclusion set */
-	exclusion = zmalloc(sizeof(*exclusion) + LTTNG_SYMBOL_NAME_LEN);
+	exclusion = zmalloc(sizeof(*exclusion) +
+		LTTNG_SYMBOL_NAME_LEN * exclusion_count);
 	if (!exclusion) {
 		PERROR("zmalloc");
 	}
 
 	ok(exclusion != NULL, "Create UST exclusion");
 
-	exclusion->count = 1;
-	strncpy((char *)(exclusion->names), get_random_string(), LTTNG_SYMBOL_NAME_LEN);
+	exclusion->count = exclusion_count;
+	random_name = get_random_string();
+	strncpy(LTTNG_EVENT_EXCLUSION_NAME_AT(exclusion, 0), random_name,
+		LTTNG_SYMBOL_NAME_LEN);
+	strncpy(LTTNG_EVENT_EXCLUSION_NAME_AT(exclusion, 1), random_name,
+		LTTNG_SYMBOL_NAME_LEN);
 
 	event = trace_ust_create_event(&ev, NULL, NULL, exclusion);
 
-	ok(event != NULL, "Create UST event with exclusion");
+	ok(!event, "Create UST event with identical exclusion names fails");
+
+	exclusion = zmalloc(sizeof(*exclusion) +
+		LTTNG_SYMBOL_NAME_LEN * exclusion_count);
+	if (!exclusion) {
+		PERROR("zmalloc");
+	}
+
+	exclusion->count = exclusion_count;
+	strncpy(LTTNG_EVENT_EXCLUSION_NAME_AT(exclusion, 0),
+		get_random_string(), LTTNG_SYMBOL_NAME_LEN);
+	strncpy(LTTNG_EVENT_EXCLUSION_NAME_AT(exclusion, 1),
+		get_random_string(), LTTNG_SYMBOL_NAME_LEN);
+
+	event = trace_ust_create_event(&ev, NULL, NULL, exclusion);
+	assert(event != NULL);
+
+	ok(event != NULL, "Create UST event with different exclusion names");
 
 	ok(event->enabled == 0 &&
 	   event->attr.instrumentation == LTTNG_UST_TRACEPOINT &&
 	   strcmp(event->attr.name, ev.name) == 0 &&
 	   event->exclusion != NULL &&
-	   event->exclusion->count == 1 &&
-	   strcmp((char *)(event->exclusion->names), (char *)(exclusion->names)) == 0 &&
+	   event->exclusion->count == exclusion_count &&
+	   !memcmp(event->exclusion->names, exclusion->names,
+	   	LTTNG_SYMBOL_NAME_LEN * exclusion_count) &&
 	   event->attr.name[LTTNG_UST_SYM_NAME_LEN - 1] == '\0',
 	   "Validate UST event and exclusion");
 


### PR DESCRIPTION
Fix and implement different things related to event exclusion names.

Both validation and match algorithms are O(n²) in relation to the number of exclusion names, but this should not cause noticeable performance issues in this context.