### PR TITLE
Initialize live timer to 0 on non-live sessions

### DIFF
--- a/src/bin/lttng-sessiond/cmd.c
+++ b/src/bin/lttng-sessiond/cmd.c
@@ -2357,7 +2357,7 @@ int cmd_create_session_snapshot(char *name, struct lttng_uri *uris,
 	 * Create session in no output mode with URIs set to NULL. The uris we've
 	 * received are for a default snapshot output if one.
 	 */
-	ret = cmd_create_session_uri(name, NULL, 0, creds, -1);
+	ret = cmd_create_session_uri(name, NULL, 0, creds, 0);
 	if (ret != LTTNG_OK) {
 		goto error;
 	}

--- a/src/bin/lttng/commands/create.c
+++ b/src/bin/lttng/commands/create.c
@@ -80,7 +80,7 @@ static struct poptOption long_options[] = {
  * why this declaration exists and used ONLY in for this command.
  */
 extern int _lttng_create_session_ext(const char *name, const char *url,
-		const char *datetime, int live_timer);
+		const char *datetime);
 
 /*
  * usage
@@ -459,7 +459,7 @@ static int create_session(void)
 		}
 		ret = lttng_create_session_live(session_name, url, opt_live_timer);
 	} else {
-		ret = _lttng_create_session_ext(session_name, url, datetime, -1);
+		ret = _lttng_create_session_ext(session_name, url, datetime);
 	}
 	if (ret < 0) {
 		/* Don't set ret so lttng can interpret the sessiond error. */


### PR DESCRIPTION
Fixes [bug 879](https://bugs.lttng.org/issues/879).