### PR TITLE
Include loglevel type in UST/agent event's primary key

### DIFF
--- a/src/bin/lttng-sessiond/agent.c
+++ b/src/bin/lttng-sessiond/agent.c
@@ -103,6 +103,7 @@ static int ht_match_event(struct cds_lfht_node *node,
 {
 	struct agent_event *event;
 	const struct agent_ht_key *key;
+	int ll_match;
 
 	assert(node);
 	assert(_key);
@@ -118,19 +119,11 @@ static int ht_match_event(struct cds_lfht_node *node,
 	}
 
 	/* Event loglevel value and type. */
-	if (event->loglevel_type == key->loglevel_type) {
-		/* Same loglevel type. */
-		if (key->loglevel_type != LTTNG_EVENT_LOGLEVEL_ALL) {
-			/*
-			 * Loglevel value must also match since the loglevel
-			 * type is not all.
-			 */
-			if (event->loglevel_value != key->loglevel_value) {
-				goto no_match;
-			}
-		}
-	} else {
-		/* Loglevel type is different: no match. */
+	ll_match = loglevels_match(event->loglevel_type,
+		event->loglevel_value, key->loglevel_type,
+		key->loglevel_value, LTTNG_EVENT_LOGLEVEL_ALL);
+
+	if (!ll_match) {
 		goto no_match;
 	}
 

--- a/src/bin/lttng-sessiond/agent.c
+++ b/src/bin/lttng-sessiond/agent.c
@@ -117,15 +117,23 @@ static int ht_match_event(struct cds_lfht_node *node,
 		goto no_match;
 	}
 
-	if (event->loglevel_value != key->loglevel_value) {
-		if (event->loglevel_type == LTTNG_EVENT_LOGLEVEL_ALL &&
-				key->loglevel_value == 0 &&
-				event->loglevel_value == -1) {
-			goto match;
+	/* Event loglevel value and type. */
+	if (event->loglevel_type == key->loglevel_type) {
+		/* Same loglevel type. */
+		if (key->loglevel_type != LTTNG_EVENT_LOGLEVEL_ALL) {
+			/*
+			 * Loglevel value must also match since the loglevel
+			 * type is not all.
+			 */
+			if (event->loglevel_value != key->loglevel_value) {
+				goto no_match;
+			}
 		}
+	} else {
+		/* Loglevel type is different: no match. */
 		goto no_match;
 	}
-match:
+
 	return 1;
 
 no_match:
@@ -147,6 +155,7 @@ static void add_unique_agent_event(struct lttng_ht *ht,
 
 	key.name = event->name;
 	key.loglevel_value = event->loglevel_value;
+	key.loglevel_type = event->loglevel_type;
 
 	node_ptr = cds_lfht_add_unique(ht->ht,
 			ht->hash_fct(event->node.key, lttng_ht_seed),
@@ -827,12 +836,13 @@ error:
  * Return a new object else NULL on error.
  */
 struct agent_event *agent_create_event(const char *name,
-		int loglevel_value, enum lttng_loglevel_type loglevel_type,
+		enum lttng_loglevel_type loglevel_type, int loglevel_value,
 		struct lttng_filter_bytecode *filter, char *filter_expression)
 {
 	struct agent_event *event = NULL;
 
-	DBG3("Agent create new event with name %s", name);
+	DBG3("Agent create new event with name %s, loglevel type %d and loglevel value %d",
+		name, loglevel_type, loglevel_value);
 
 	if (!name) {
 		ERR("Failed to create agent event; no name provided.");
@@ -914,7 +924,8 @@ error:
  *
  * Return object if found else NULL.
  */
-struct agent_event *agent_find_event(const char *name, int loglevel_value,
+struct agent_event *agent_find_event(const char *name,
+		enum lttng_loglevel_type loglevel_type, int loglevel_value,
 		struct agent *agt)
 {
 	struct lttng_ht_node_str *node;
@@ -929,6 +940,7 @@ struct agent_event *agent_find_event(const char *name, int loglevel_value,
 	ht = agt->events;
 	key.name = name;
 	key.loglevel_value = loglevel_value;
+	key.loglevel_type = loglevel_type;
 
 	cds_lfht_lookup(ht->ht, ht->hash_fct((void *) name, lttng_ht_seed),
 			ht_match_event, &key, &iter.iter);

--- a/src/bin/lttng-sessiond/agent.h
+++ b/src/bin/lttng-sessiond/agent.h
@@ -37,6 +37,7 @@ extern struct lttng_ht *agent_apps_ht_by_sock;
 struct agent_ht_key {
 	const char *name;
 	int loglevel_value;
+	enum lttng_loglevel_type loglevel_type;
 };
 
 /*
@@ -131,13 +132,14 @@ void agent_destroy(struct agent *agt);
 void agent_add(struct agent *agt, struct lttng_ht *ht);
 
 /* Agent event API. */
-struct agent_event *agent_create_event(const char *name, int loglevel,
-		enum lttng_loglevel_type loglevel_type,
+struct agent_event *agent_create_event(const char *name,
+		enum lttng_loglevel_type loglevel_type, int loglevel_value,
 		struct lttng_filter_bytecode *filter,
 		char *filter_expression);
 void agent_add_event(struct agent_event *event, struct agent *agt);
 
-struct agent_event *agent_find_event(const char *name, int loglevel,
+struct agent_event *agent_find_event(const char *name,
+		enum lttng_loglevel_type loglevel_type, int loglevel_value,
 		struct agent *agt);
 struct agent_event *agent_find_event_by_name(const char *name,
 		struct agent *agt);

--- a/src/bin/lttng-sessiond/agent.h
+++ b/src/bin/lttng-sessiond/agent.h
@@ -36,7 +36,7 @@ extern struct lttng_ht *agent_apps_ht_by_sock;
 
 struct agent_ht_key {
 	const char *name;
-	int loglevel;
+	int loglevel_value;
 };
 
 /*
@@ -80,7 +80,7 @@ struct agent_app {
 struct agent_event {
 	/* Name of the event. */
 	char name[LTTNG_SYMBOL_NAME_LEN];
-	int loglevel;
+	int loglevel_value;
 	enum lttng_loglevel_type loglevel_type;
 
 	/*

--- a/src/bin/lttng-sessiond/cmd.c
+++ b/src/bin/lttng-sessiond/cmd.c
@@ -237,7 +237,7 @@ static int list_lttng_agent_events(struct agent *agt,
 		strncpy(tmp_events[i].name, event->name, sizeof(tmp_events[i].name));
 		tmp_events[i].name[sizeof(tmp_events[i].name) - 1] = '\0';
 		tmp_events[i].enabled = event->enabled;
-		tmp_events[i].loglevel = event->loglevel;
+		tmp_events[i].loglevel = event->loglevel_value;
 		tmp_events[i].loglevel_type = event->loglevel_type;
 		i++;
 	}

--- a/src/bin/lttng-sessiond/event.c
+++ b/src/bin/lttng-sessiond/event.c
@@ -50,7 +50,8 @@ static void add_unique_ust_event(struct lttng_ht *ht,
 
 	key.name = event->attr.name;
 	key.filter = (struct lttng_filter_bytecode *) event->filter;
-	key.loglevel_type = event->attr.loglevel;
+	key.loglevel_type = event->attr.loglevel_type;
+	key.loglevel_value = event->attr.loglevel;
 	key.exclusion = event->exclusion;
 
 	node_ptr = cds_lfht_add_unique(ht->ht,
@@ -207,7 +208,7 @@ int event_ust_enable_tracepoint(struct ltt_ust_session *usess,
 	rcu_read_lock();
 
 	uevent = trace_ust_find_event(uchan->events, event->name, filter,
-			event->loglevel, exclusion);
+			event->loglevel_type, event->loglevel, exclusion);
 	if (!uevent) {
 		uevent = trace_ust_create_event(event, filter_expression,
 				filter, exclusion, internal_event);
@@ -533,12 +534,13 @@ int event_agent_disable(struct ltt_ust_session *usess, struct agent *agt,
 	}
 
 	/*
-	 * The loglevel is hardcoded with 0 here since the agent ust event is set
-	 * with the loglevel type to ALL thus the loglevel stays 0. The event's
-	 * filter is the one handling the loglevel for agent.
+	 * Agent UST event has its loglevel type forced to
+	 * LTTNG_UST_LOGLEVEL_ALL. The actual loglevel type/value filtering
+	 * happens thanks to an UST filter. The following -1 is actually
+	 * ignored since the type is LTTNG_UST_LOGLEVEL_ALL.
 	 */
 	uevent = trace_ust_find_event(uchan->events, (char *) ust_event_name,
-			aevent->filter, 0, NULL);
+			aevent->filter, LTTNG_UST_LOGLEVEL_ALL, -1, NULL);
 	/* If the agent event exists, it must be available on the UST side. */
 	assert(uevent);
 

--- a/src/bin/lttng-sessiond/event.c
+++ b/src/bin/lttng-sessiond/event.c
@@ -50,7 +50,7 @@ static void add_unique_ust_event(struct lttng_ht *ht,
 
 	key.name = event->attr.name;
 	key.filter = (struct lttng_filter_bytecode *) event->filter;
-	key.loglevel = event->attr.loglevel;
+	key.loglevel_type = event->attr.loglevel;
 	key.exclusion = event->exclusion;
 
 	node_ptr = cds_lfht_add_unique(ht->ht,

--- a/src/bin/lttng-sessiond/event.c
+++ b/src/bin/lttng-sessiond/event.c
@@ -412,10 +412,11 @@ int event_agent_enable(struct ltt_ust_session *usess,
 			usess->id, event->loglevel_type, event->loglevel,
 			filter_expression ? filter_expression : "NULL");
 
-	aevent = agent_find_event(event->name, event->loglevel, agt);
+	aevent = agent_find_event(event->name, event->loglevel_type,
+		event->loglevel, agt);
 	if (!aevent) {
-		aevent = agent_create_event(event->name, event->loglevel,
-				event->loglevel_type, filter,
+		aevent = agent_create_event(event->name, event->loglevel_type,
+				event->loglevel, filter,
 				filter_expression);
 		if (!aevent) {
 			ret = LTTNG_ERR_NOMEM;

--- a/src/bin/lttng-sessiond/lttng-ust-ctl.h
+++ b/src/bin/lttng-sessiond/lttng-ust-ctl.h
@@ -356,7 +356,7 @@ int ustctl_recv_register_event(int sock,
 					 * event name (output,
 					 * size LTTNG_UST_SYM_NAME_LEN)
 					 */
-	int *loglevel,
+	int *loglevel_value,
 	char **signature,		/*
 					 * event signature
 					 * (output, dynamically

--- a/src/bin/lttng-sessiond/save.c
+++ b/src/bin/lttng-sessiond/save.c
@@ -749,7 +749,7 @@ void init_ust_event_from_agent_event(struct ltt_ust_event *ust_event,
 	ust_event->attr.instrumentation = LTTNG_UST_TRACEPOINT;
 	strncpy(ust_event->attr.name, agent_event->name, LTTNG_SYMBOL_NAME_LEN);
 	ust_event->attr.loglevel_type = agent_event->loglevel_type;
-	ust_event->attr.loglevel = agent_event->loglevel;
+	ust_event->attr.loglevel = agent_event->loglevel_value;
 	ust_event->filter_expression = agent_event->filter_expression;
 	ust_event->exclusion = agent_event->exclusion;
 }

--- a/src/bin/lttng-sessiond/trace-ust.c
+++ b/src/bin/lttng-sessiond/trace-ust.c
@@ -72,6 +72,7 @@ int trace_ust_ht_match_event(struct cds_lfht_node *node, const void *_key)
 	struct ltt_ust_event *event;
 	const struct ltt_ust_ht_key *key;
 	int ev_loglevel_value;
+	int ll_match;
 
 	assert(node);
 	assert(_key);
@@ -88,19 +89,11 @@ int trace_ust_ht_match_event(struct cds_lfht_node *node, const void *_key)
 	}
 
 	/* Event loglevel value and type. */
-	if (event->attr.loglevel_type == key->loglevel_type) {
-		/* Same loglevel type. */
-		if (key->loglevel_type != LTTNG_UST_LOGLEVEL_ALL) {
-			/*
-			 * Loglevel value must also match since the loglevel
-			 * type is not all.
-			 */
-			if (ev_loglevel_value != key->loglevel_value) {
-				goto no_match;
-			}
-		}
-	} else {
-		/* Loglevel type is different: no match. */
+	ll_match = loglevels_match(event->attr.loglevel_type,
+		ev_loglevel_value, key->loglevel_type,
+		key->loglevel_value, LTTNG_UST_LOGLEVEL_ALL);
+
+	if (!ll_match) {
 		goto no_match;
 	}
 

--- a/src/bin/lttng-sessiond/trace-ust.c
+++ b/src/bin/lttng-sessiond/trace-ust.c
@@ -87,19 +87,21 @@ int trace_ust_ht_match_event(struct cds_lfht_node *node, const void *_key)
 		goto no_match;
 	}
 
-	/* Event loglevel. */
-	if (ev_loglevel_value != key->loglevel_type) {
-		if (event->attr.loglevel_type == LTTNG_UST_LOGLEVEL_ALL
-				&& key->loglevel_type == 0 && ev_loglevel_value == -1) {
+	/* Event loglevel value and type. */
+	if (event->attr.loglevel_type == key->loglevel_type) {
+		/* Same loglevel type. */
+		if (key->loglevel_type != LTTNG_UST_LOGLEVEL_ALL) {
 			/*
-			 * Match is accepted. This is because on event creation, the
-			 * loglevel is set to -1 if the event loglevel type is ALL so 0 and
-			 * -1 are accepted for this loglevel type since 0 is the one set by
-			 * the API when receiving an enable event.
+			 * Loglevel value must also match since the loglevel
+			 * type is not all.
 			 */
-		} else {
-			goto no_match;
+			if (ev_loglevel_value != key->loglevel_value) {
+				goto no_match;
+			}
 		}
+	} else {
+		/* Loglevel type is different: no match. */
+		goto no_match;
 	}
 
 	/* Only one of the filters is NULL, fail. */
@@ -174,7 +176,8 @@ error:
  */
 struct ltt_ust_event *trace_ust_find_event(struct lttng_ht *ht,
 		char *name, struct lttng_filter_bytecode *filter,
-		int loglevel_value, struct lttng_event_exclusion *exclusion)
+		enum lttng_ust_loglevel_type loglevel_type, int loglevel_value,
+		struct lttng_event_exclusion *exclusion)
 {
 	struct lttng_ht_node_str *node;
 	struct lttng_ht_iter iter;
@@ -185,7 +188,8 @@ struct ltt_ust_event *trace_ust_find_event(struct lttng_ht *ht,
 
 	key.name = name;
 	key.filter = filter;
-	key.loglevel_type = loglevel_value;
+	key.loglevel_type = loglevel_type;
+	key.loglevel_value = loglevel_value;
 	key.exclusion = exclusion;
 
 	cds_lfht_lookup(ht->ht, ht->hash_fct((void *) name, lttng_ht_seed),

--- a/src/bin/lttng-sessiond/trace-ust.c
+++ b/src/bin/lttng-sessiond/trace-ust.c
@@ -71,12 +71,14 @@ int trace_ust_ht_match_event(struct cds_lfht_node *node, const void *_key)
 {
 	struct ltt_ust_event *event;
 	const struct ltt_ust_ht_key *key;
+	int ev_loglevel_value;
 
 	assert(node);
 	assert(_key);
 
 	event = caa_container_of(node, struct ltt_ust_event, node.node);
 	key = _key;
+	ev_loglevel_value = event->attr.loglevel;
 
 	/* Match the 4 elements of the key: name, filter, loglevel, exclusions. */
 
@@ -86,9 +88,9 @@ int trace_ust_ht_match_event(struct cds_lfht_node *node, const void *_key)
 	}
 
 	/* Event loglevel. */
-	if (event->attr.loglevel != key->loglevel) {
+	if (ev_loglevel_value != key->loglevel_type) {
 		if (event->attr.loglevel_type == LTTNG_UST_LOGLEVEL_ALL
-				&& key->loglevel == 0 && event->attr.loglevel == -1) {
+				&& key->loglevel_type == 0 && ev_loglevel_value == -1) {
 			/*
 			 * Match is accepted. This is because on event creation, the
 			 * loglevel is set to -1 if the event loglevel type is ALL so 0 and
@@ -171,8 +173,8 @@ error:
  * MUST be acquired before calling this.
  */
 struct ltt_ust_event *trace_ust_find_event(struct lttng_ht *ht,
-		char *name, struct lttng_filter_bytecode *filter, int loglevel,
-		struct lttng_event_exclusion *exclusion)
+		char *name, struct lttng_filter_bytecode *filter,
+		int loglevel_value, struct lttng_event_exclusion *exclusion)
 {
 	struct lttng_ht_node_str *node;
 	struct lttng_ht_iter iter;
@@ -183,7 +185,7 @@ struct ltt_ust_event *trace_ust_find_event(struct lttng_ht *ht,
 
 	key.name = name;
 	key.filter = filter;
-	key.loglevel = loglevel;
+	key.loglevel_type = loglevel_value;
 	key.exclusion = exclusion;
 
 	cds_lfht_lookup(ht->ht, ht->hash_fct((void *) name, lttng_ht_seed),

--- a/src/bin/lttng-sessiond/trace-ust.h
+++ b/src/bin/lttng-sessiond/trace-ust.h
@@ -34,7 +34,7 @@ struct agent;
 struct ltt_ust_ht_key {
 	const char *name;
 	const struct lttng_filter_bytecode *filter;
-	enum lttng_ust_loglevel_type loglevel;
+	enum lttng_ust_loglevel_type loglevel_type;
 	const struct lttng_event_exclusion *exclusion;
 };
 
@@ -183,8 +183,8 @@ int trace_ust_ht_match_event_by_name(struct cds_lfht_node *node,
  * Lookup functions. NULL is returned if not found.
  */
 struct ltt_ust_event *trace_ust_find_event(struct lttng_ht *ht,
-		char *name, struct lttng_filter_bytecode *filter, int loglevel,
-		struct lttng_event_exclusion *exclusion);
+		char *name, struct lttng_filter_bytecode *filter,
+		int loglevel_value, struct lttng_event_exclusion *exclusion);
 struct ltt_ust_channel *trace_ust_find_channel_by_name(struct lttng_ht *ht,
 		char *name);
 struct agent *trace_ust_find_agent(struct ltt_ust_session *session,
@@ -290,8 +290,8 @@ int trace_ust_match_context(struct ltt_ust_context *uctx,
 	return 0;
 }
 static inline struct ltt_ust_event *trace_ust_find_event(struct lttng_ht *ht,
-		char *name, struct lttng_filter_bytecode *filter, int loglevel,
-		struct lttng_event_exclusion *exclusion)
+		char *name, struct lttng_filter_bytecode *filter,
+		int loglevel_value, struct lttng_event_exclusion *exclusion)
 {
 	return NULL;
 }

--- a/src/bin/lttng-sessiond/trace-ust.h
+++ b/src/bin/lttng-sessiond/trace-ust.h
@@ -35,6 +35,7 @@ struct ltt_ust_ht_key {
 	const char *name;
 	const struct lttng_filter_bytecode *filter;
 	enum lttng_ust_loglevel_type loglevel_type;
+	int loglevel_value;
 	const struct lttng_event_exclusion *exclusion;
 };
 
@@ -184,7 +185,8 @@ int trace_ust_ht_match_event_by_name(struct cds_lfht_node *node,
  */
 struct ltt_ust_event *trace_ust_find_event(struct lttng_ht *ht,
 		char *name, struct lttng_filter_bytecode *filter,
-		int loglevel_value, struct lttng_event_exclusion *exclusion);
+		enum lttng_ust_loglevel_type loglevel_type, int loglevel_value,
+		struct lttng_event_exclusion *exclusion);
 struct ltt_ust_channel *trace_ust_find_channel_by_name(struct lttng_ht *ht,
 		char *name);
 struct agent *trace_ust_find_agent(struct ltt_ust_session *session,

--- a/src/bin/lttng-sessiond/ust-app.h
+++ b/src/bin/lttng-sessiond/ust-app.h
@@ -15,7 +15,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef _LTT_UST_APP_H 
+#ifndef _LTT_UST_APP_H
 #define _LTT_UST_APP_H
 
 #include <stdint.h>
@@ -48,7 +48,7 @@ struct ust_app_notify_sock_obj {
 struct ust_app_ht_key {
 	const char *name;
 	const struct lttng_filter_bytecode *filter;
-	enum lttng_ust_loglevel_type loglevel;
+	enum lttng_ust_loglevel_type loglevel_type;
 	const struct lttng_event_exclusion *exclusion;
 };
 

--- a/src/bin/lttng-sessiond/ust-metadata.c
+++ b/src/bin/lttng-sessiond/ust-metadata.c
@@ -359,7 +359,7 @@ int ust_metadata_event_statedump(struct ust_registry_session *session,
 
 	ret = lttng_metadata_printf(session,
 		"	loglevel = %d;\n",
-		event->loglevel);
+		event->loglevel_value);
 	if (ret)
 		goto end;
 

--- a/src/bin/lttng-sessiond/ust-registry.c
+++ b/src/bin/lttng-sessiond/ust-registry.c
@@ -133,8 +133,8 @@ int validate_event_fields(size_t nr_fields, struct ustctl_field *fields,
  */
 static struct ust_registry_event *alloc_event(int session_objd,
 		int channel_objd, char *name, char *sig, size_t nr_fields,
-		struct ustctl_field *fields, int loglevel, char *model_emf_uri,
-		struct ust_app *app)
+		struct ustctl_field *fields, int loglevel_value,
+		char *model_emf_uri, struct ust_app *app)
 {
 	struct ust_registry_event *event = NULL;
 
@@ -157,7 +157,7 @@ static struct ust_registry_event *alloc_event(int session_objd,
 	event->signature = sig;
 	event->nr_fields = nr_fields;
 	event->fields = fields;
-	event->loglevel = loglevel;
+	event->loglevel_value = loglevel_value;
 	event->model_emf_uri = model_emf_uri;
 	if (name) {
 		/* Copy event name and force NULL byte. */
@@ -248,9 +248,9 @@ end:
  */
 int ust_registry_create_event(struct ust_registry_session *session,
 		uint64_t chan_key, int session_objd, int channel_objd, char *name,
-		char *sig, size_t nr_fields, struct ustctl_field *fields, int loglevel,
-		char *model_emf_uri, int buffer_type, uint32_t *event_id_p,
-		struct ust_app *app)
+		char *sig, size_t nr_fields, struct ustctl_field *fields,
+		int loglevel_value, char *model_emf_uri, int buffer_type,
+		uint32_t *event_id_p, struct ust_app *app)
 {
 	int ret;
 	uint32_t event_id;
@@ -287,7 +287,7 @@ int ust_registry_create_event(struct ust_registry_session *session,
 	}
 
 	event = alloc_event(session_objd, channel_objd, name, sig, nr_fields,
-			fields, loglevel, model_emf_uri, app);
+			fields, loglevel_value, model_emf_uri, app);
 	if (!event) {
 		ret = -ENOMEM;
 		goto error_free;

--- a/src/bin/lttng-sessiond/ust-registry.h
+++ b/src/bin/lttng-sessiond/ust-registry.h
@@ -139,7 +139,7 @@ struct ust_registry_event {
 	/* Name of the event returned by the tracer. */
 	char name[LTTNG_UST_SYM_NAME_LEN];
 	char *signature;
-	int loglevel;
+	int loglevel_value;
 	size_t nr_fields;
 	struct ustctl_field *fields;
 	char *model_emf_uri;
@@ -244,9 +244,9 @@ void ust_registry_session_destroy(struct ust_registry_session *session);
 
 int ust_registry_create_event(struct ust_registry_session *session,
 		uint64_t chan_key, int session_objd, int channel_objd, char *name,
-		char *sig, size_t nr_fields, struct ustctl_field *fields, int loglevel,
-		char *model_emf_uri, int buffer_type, uint32_t *event_id_p,
-		struct ust_app *app);
+		char *sig, size_t nr_fields, struct ustctl_field *fields,
+		int loglevel_value, char *model_emf_uri, int buffer_type,
+		uint32_t *event_id_p, struct ust_app *app);
 struct ust_registry_event *ust_registry_find_event(
 		struct ust_registry_channel *chan, char *name, char *sig);
 void ust_registry_destroy_event(struct ust_registry_channel *chan,
@@ -302,8 +302,9 @@ void ust_registry_session_destroy(struct ust_registry_session *session)
 static inline
 int ust_registry_create_event(struct ust_registry_session *session,
 		uint64_t chan_key, int session_objd, int channel_objd, char *name,
-		char *sig, size_t nr_fields, struct ustctl_field *fields, int loglevel,
-		char *model_emf_uri, int buffer_type, uint32_t *event_id_p)
+		char *sig, size_t nr_fields, struct ustctl_field *fields,
+		int loglevel_value, char *model_emf_uri, int buffer_type,
+		uint32_t *event_id_p)
 {
 	return 0;
 }

--- a/src/bin/lttng-sessiond/utils.c
+++ b/src/bin/lttng-sessiond/utils.c
@@ -72,3 +72,27 @@ void ht_cleanup_push(struct lttng_ht *ht)
 error:
 	assert(!ret);
 }
+
+int loglevels_match(int a_loglevel_type, int a_loglevel_value,
+	int b_loglevel_type, int b_loglevel_value, int loglevel_all_type)
+{
+	int match = 1;
+
+	if (a_loglevel_type == b_loglevel_type) {
+		/* Same loglevel type. */
+		if (b_loglevel_type != loglevel_all_type) {
+			/*
+			 * Loglevel value must also match since the loglevel
+			 * type is not all.
+			 */
+			if (a_loglevel_value != b_loglevel_value) {
+				match = 0;
+			}
+		}
+	} else {
+		/* Loglevel type is different: no match. */
+		match = 0;
+	}
+
+	return match;
+}

--- a/src/bin/lttng-sessiond/utils.h
+++ b/src/bin/lttng-sessiond/utils.h
@@ -23,5 +23,7 @@ struct lttng_ht;
 const char *get_home_dir(void);
 int notify_thread_pipe(int wpipe);
 void ht_cleanup_push(struct lttng_ht *ht);
+int loglevels_match(int a_loglevel_type, int a_loglevel_value,
+	int b_loglevel_type, int b_loglevel_value, int loglevel_all_type);
 
 #endif /* _LTT_UTILS_H */

--- a/src/common/sessiond-comm/agent.h
+++ b/src/common/sessiond-comm/agent.h
@@ -59,7 +59,7 @@ struct lttcomm_agent_hdr {
  * Enable event command payload.
  */
 struct lttcomm_agent_enable {
-	uint32_t loglevel;
+	uint32_t loglevel_value;
 	uint32_t loglevel_type;
 	char name[LTTNG_SYMBOL_NAME_LEN];
 } LTTNG_PACKED;


### PR DESCRIPTION
This one adds the loglevel type to UST/agent event's unique tuple of properties making up its primary key. Currently, only the loglevel is checked, so that

    lttng enable-event -u event --loglevel TRACE_INFO

passes and

    lttng enable-event -u event --loglevel-only TRACE_INFO

fails since the latter is identified as the same event as the former.