### PR TITLE
Fix: memleak in utils_partial_realpath

### DIFF
--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -55,7 +55,7 @@
 LTTNG_HIDDEN
 char *utils_partial_realpath(const char *path, char *resolved_path, size_t size)
 {
-	char *cut_path, *try_path = NULL, *try_path_prev = NULL;
+	char *cut_path = NULL, *try_path = NULL, *try_path_prev = NULL;
 	const char *next, *prev, *end;
 
 	/* Safety net */
@@ -174,6 +174,7 @@ char *utils_partial_realpath(const char *path, char *resolved_path, size_t size)
 
 error:
 	free(resolved_path);
+	free(cut_path);
 	return NULL;
 }
 


### PR DESCRIPTION
`cut_path` would leak when following the error path at line 115.

Signed-off-by: Antoine Busque <abusque@efficios.com>