### PR TITLE
Fix: lttng-crash: don't segfault on -e flag

### DIFF
--- a/src/bin/lttng-crash/lttng-crash.c
+++ b/src/bin/lttng-crash/lttng-crash.c
@@ -275,7 +275,7 @@ static int parse_args(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
-	while ((opt = getopt_long(argc, argv, "+Vhvex:", long_options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "+Vhve:x:", long_options, NULL)) != -1) {
 		switch (opt) {
 		case 'V':
 			version(stdout);


### PR DESCRIPTION
The optstring parameter given to `getopt_long` was such that when
passing the -e flag to specify a viewer other than the default,
`optarg` would remain NULL and cause a segfault when passing it to
`strdup`. A colon after the flag in the optstring makes the function
expect a following argument, in this case the path to the viewer.

Signed-off-by: Antoine Busque <abusque@efficios.com>