### PR TITLE
Fix: prevent dangling pointer in utils_partial_realpath

### DIFF
--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -124,6 +124,7 @@ char *utils_partial_realpath(const char *path, char *resolved_path, size_t size)
 
 		/* Free the allocated memory */
 		free(cut_path);
+		cut_path = NULL;
 	};
 
 	/* Allocate memory for the resolved path if necessary */


### PR DESCRIPTION
In my attempt to fix a memory leak, I missed a codepath in the function which would cause a double free on `cut_path` should the memory allocation for `resolved_path` fail at line 131/132, due to a dangling pointer from the preceding loop. This PR therefore fixes this by setting `cut_path` to `NULL` after freeing.