### PR TITLE
Only compare "bison -y" to the basename of YACC variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -704,7 +704,7 @@ AM_CONDITIONAL([BUILD_LIB_TESTPOINT], [test x$build_lib_testpoint = xyes])
 AM_CONDITIONAL([BUILD_LIB_UST_CONSUMER], [test x$build_lib_ust_consumer = xyes])
 
 if test ! -f "$srcdir/src/lib/lttng-ctl/filter/filter-parser.h"; then
-	if test x"$YACC" != "xbison -y"; then
+	if test x"$(basename "$YACC")" != "xbison -y"; then
 		AC_MSG_ERROR([[bison not found and is required when building from git.
 		Please install bison]])
 	fi


### PR DESCRIPTION
In the event that the YACC variable is set to a full path
this test fail even if it should not.

Signed-off-by: Jonathan Rajotte <jonathan.rajotte-julien@efficios.com>