### PR TITLE
Fixes bug 973 from bugs.lttng.org

### DIFF
--- a/include/lttng/handle.h
+++ b/include/lttng/handle.h
@@ -43,6 +43,10 @@ struct lttng_handle {
  * This handle contains the session name and domain on which the command will
  * be executed. A domain is basically a tracer like the kernel or user space.
  *
+ * When domain is memset to 0 it indicate the handle is not bound to a specific
+ * domain. This is mostly used for actions that apply on a session and not a
+ * specific domain (e.g lttng_set_consumer_url).
+ *
  * Return an newly allocated handle that should be freed using
  * lttng_destroy_handle. On error, NULL is returned.
  */

--- a/src/bin/lttng/commands/create.c
+++ b/src/bin/lttng/commands/create.c
@@ -146,7 +146,7 @@ static int set_consumer_url(const char *session_name, const char *ctrl_url,
 	assert(session_name);
 
 	/*
-	 * Set handle with the session name and the domain set to 0. This means to
+	 * Set handle with the domain set to 0. This means to
 	 * the session daemon that the next action applies on the tracing session
 	 * rather then the domain specific session.
 	 */

--- a/tests/regression/tools/save-load/load-42-complex.lttng
+++ b/tests/regression/tools/save-load/load-42-complex.lttng
@@ -96,6 +96,21 @@
 					</channel>
 				</channels>
 			</domain>
+			<domain>
+				<type>JUL</type>
+				<buffer_type>PER_UID</buffer_type>
+				<channels/>
+			</domain>
+			<domain>
+				<type>LOG4J</type>
+				<buffer_type>PER_UID</buffer_type>
+				<channels/>
+			</domain>
+			<domain>
+				<type>PYTHON</type>
+				<buffer_type>PER_UID</buffer_type>
+				<channels/>
+			</domain>
 		</domains>
 		<started>false</started>
 		<attributes>

--- a/tests/regression/tools/save-load/test_load
+++ b/tests/regression/tools/save-load/test_load
@@ -74,7 +74,7 @@ function test_complex_load()
 		break;
 	fi
 	$TESTDIR/../src/bin/lttng/$LTTNG_BIN --mi XML list $sess -c chan2 > $mi_output_file
-	mi_result=$($CURDIR/../mi/extract_xml $mi_output_file "//lttng:command/lttng:output/lttng:sessions/lttng:session/lttng:domains/lttng:domain/lttng:channels/lttng:channel[lttng:name='chan2']/lttng:events/lttng:event[lttng:name='uevent_disabled']/lttng:enabled/text()")
+	mi_result=$($CURDIR/../mi/extract_xml $mi_output_file "//lttng:command/lttng:output/lttng:sessions/lttng:session/lttng:domains/lttng:domain[lttng:type='UST']/lttng:channels/lttng:channel[lttng:name='chan2']/lttng:events/lttng:event[lttng:name='uevent_disabled']/lttng:enabled/text()")
 	if [[ $mi_result = "false" ]]; then
 	    ok 0 "Disabled event is loaded in disabled state"
 	else


### PR DESCRIPTION
URL setting are session related and not domain specific.

Pretty sure that a simple warning would have been better than an error in the first case when re-assigning the remote URL since it might be a future use case. Still, iterating over domain is unnecessary here since URL are per-session.