### PR TITLE
Tests: fix make targets using objcopy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,7 +95,9 @@ health_check
 tests/regression/ust/python-logging/test_python_logging
 /tests/regression/ust/baddr-statedump/prog
 /tests/regression/ust/baddr-statedump/prog.debug
+/tests/regression/ust/baddr-statedump/prog.strip
 /tests/regression/ust/ust-dl/prog
+/tests/regression/ust/ust-dl/libfoo.so.debug
 /tests/utils/testapp/gen-ust-nevents/gen-ust-nevents
 /tests/utils/testapp/gen-ust-tracef/gen-ust-tracef
 /tests/regression/tools/live/live_test

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,13 @@ AC_PROG_SED
 AC_PROG_YACC
 LT_INIT
 
+# Check for objcopy, required by the base address statedump and dynamic linker tests
+AC_CHECK_TOOL([OBJCOPY], objcopy, no)
+AS_IF([test "x$OBJCOPY" = xno],
+	[AC_MSG_WARN([Cannont find objcopy. The base address statedump and dynamic linker tests will be disabled. Install the binutils package to remediate this.])]
+)
+AM_CONDITIONAL([HAVE_OBJCOPY], [test "x$OBJCOPY" != xno])
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE
 AC_TYPE_INT32_T

--- a/tests/regression/ust/Makefile.am
+++ b/tests/regression/ust/Makefile.am
@@ -2,7 +2,11 @@ if HAVE_LIBLTTNG_UST_CTL
 SUBDIRS = nprocesses high-throughput low-throughput before-after multi-session \
 		overlap buffers-pid linking daemon exit-fast fork libc-wrapper \
 		periodical-metadata-flush java-jul java-log4j python-logging \
-		getcpu-override clock-override baddr-statedump ust-dl
+		getcpu-override clock-override
+
+if HAVE_OBJCOPY
+SUBDIRS += baddr-statedump ust-dl
+endif
 
 EXTRA_DIST = test_event_basic test_event_tracef test_event_perf
 

--- a/tests/regression/ust/baddr-statedump/Makefile.am
+++ b/tests/regression/ust/baddr-statedump/Makefile.am
@@ -1,3 +1,7 @@
+objcopy_verbose = $(objcopy_verbose_@AM_V@)
+objcopy_verbose_ = $(objcopy_verbose_@AM_DEFAULT_V@)
+objcopy_verbose_0 = @echo OBJCOPY $@;
+
 AM_CPPFLAGS = -I$(srcdir) -g
 
 noinst_PROGRAMS = prog
@@ -7,15 +11,21 @@ prog_LDADD = -llttng-ust -ldl
 noinst_SCRIPTS = test_baddr-statedump test_baddr-statedump.py
 EXTRA_DIST = test_baddr-statedump test_baddr-statedump.py
 
-all-local: prog$(EXEEXT)
+# Extract debug symbols
+prog.debug: prog
+	$(objcopy_verbose)$(OBJCOPY) --only-keep-debug prog prog.debug
+
+# Strip and add debuglink
+prog.strip: prog.debug
+	@cp -f prog prog.strip
+	$(objcopy_verbose)$(OBJCOPY) --strip-debug --add-gnu-debuglink=prog.debug prog.strip
+
+all-local: prog.strip
 	@if [ x"$(srcdir)" != x"$(builddir)" ]; then \
 		for script in $(EXTRA_DIST); do \
 			cp -f $(srcdir)/$$script $(builddir); \
 		done; \
 	fi
-	objcopy --only-keep-debug prog prog.debug
-	strip -g prog
-	objcopy --add-gnu-debuglink prog.debug prog
 
 clean-local:
 	@if [ x"$(srcdir)" != x"$(builddir)" ]; then \
@@ -23,4 +33,5 @@ clean-local:
 			rm -f $(builddir)/$$script; \
 		done; \
 	fi
-	rm -f prog.debug
+
+CLEANFILES = prog.debug prog.strip

--- a/tests/regression/ust/baddr-statedump/test_baddr-statedump.py
+++ b/tests/regression/ust/baddr-statedump/test_baddr-statedump.py
@@ -45,7 +45,7 @@ session_info = create_session()
 enable_ust_tracepoint_event(session_info, "*")
 start_session(session_info)
 
-test_process = subprocess.Popen(test_path + "prog", stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+test_process = subprocess.Popen(test_path + "prog.strip", stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 if sys.version_info >= (3, 3):
     try:
         test_process.wait(5)

--- a/tests/regression/ust/ust-dl/Makefile.am
+++ b/tests/regression/ust/ust-dl/Makefile.am
@@ -1,3 +1,7 @@
+objcopy_verbose = $(objcopy_verbose_@AM_V@)
+objcopy_verbose_ = $(objcopy_verbose_@AM_DEFAULT_V@)
+objcopy_verbose_0 = @echo OBJCOPY $@;
+
 AM_CPPFLAGS = -I$(srcdir) -g
 
 noinst_PROGRAMS = prog
@@ -12,15 +16,21 @@ libfoo_la_LDFLAGS = -module -shared -avoid-version \
 noinst_SCRIPTS = test_ust-dl test_ust-dl.py
 EXTRA_DIST = test_ust-dl test_ust-dl.py
 
-all-local: libfoo.la
+# Extract debug symbols
+libfoo.so.debug: libfoo.la
+	$(objcopy_verbose)$(OBJCOPY) --only-keep-debug .libs/libfoo.so libfoo.so.debug
+
+# Strip and add debuglink
+libfoo.so: libfoo.so.debug
+	@cp -f .libs/libfoo.so libfoo.so
+	$(objcopy_verbose)$(OBJCOPY) --strip-debug --add-gnu-debuglink=libfoo.so.debug libfoo.so
+
+all-local: libfoo.so
 	@if [ x"$(srcdir)" != x"$(builddir)" ]; then \
 		for script in $(EXTRA_DIST); do \
 			cp -f $(srcdir)/$$script $(builddir); \
 		done; \
 	fi
-	objcopy --only-keep-debug .libs/libfoo.so .libs/libfoo.so.debug
-	strip -g .libs/libfoo.so
-	objcopy --add-gnu-debuglink .libs/libfoo.so.debug .libs/libfoo.so
 
 clean-local:
 	@if [ x"$(srcdir)" != x"$(builddir)" ]; then \
@@ -28,4 +38,5 @@ clean-local:
 			rm -f $(builddir)/$$script; \
 		done; \
 	fi
-	rm -f .libs/libfoo.so.debug
+
+CLEANFILES = libfoo.so libfoo.so.debug

--- a/tests/regression/ust/ust-dl/test_ust-dl.py
+++ b/tests/regression/ust/ust-dl/test_ust-dl.py
@@ -47,7 +47,7 @@ start_session(session_info)
 
 test_env = os.environ.copy()
 test_env["LD_PRELOAD"] = "liblttng-ust-dl.so"
-test_env["LD_LIBRARY_PATH"] = test_path + ".libs/"
+test_env["LD_LIBRARY_PATH"] = test_path
 test_process = subprocess.Popen(test_path + "prog",
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                 env=test_env)


### PR DESCRIPTION
Add detection for objcopy using AC_CHECK_TOOL and use dedicated make
targets for each file.