### PR TITLE
Fix build system for pregenerated stuff

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -500,7 +500,7 @@ AC_ARG_ENABLE(
 	man-pages,
 	AS_HELP_STRING(
 		[--disable-man-pages],
-		[Build and install man pages (already built in a distributed tarball)]
+		[Do not build and install man pages (already built in a distributed tarball)]
 	),
 	[man_pages_opt=$enableval],
 	[man_pages_opt=yes]

--- a/configure.ac
+++ b/configure.ac
@@ -495,29 +495,56 @@ fi
 AS_IF([test -f "$srcdir/bootstrap"], [in_git_repo=yes], [in_git_repo=no])
 AM_CONDITIONAL([IN_GIT_REPO], [test "x$in_git_repo" = "xyes"])
 
-# enable building man pages
+# enable building man pages (user's intention)
 AC_ARG_ENABLE(
-	build-man-pages,
+	man-pages,
 	AS_HELP_STRING(
-		[--disable-build-man-pages],
-		[Build man pages (already built in a distributed tarball)]
+		[--disable-man-pages],
+		[Build and install man pages (already built in a distributed tarball)]
 	),
-	[build_man_pages=$enableval],
-	[build_man_pages=yes]
+	[man_pages_opt=$enableval],
+	[man_pages_opt=yes]
 )
 
-# export man page build condition
-AM_CONDITIONAL([BUILD_MAN_PAGES], [test "x$build_man_pages" != "xno"])
-
 # check for asciidoc and xmlto if we enabled building the man pages
-AS_IF([test "x$build_man_pages" = "xyes"], [
+have_asciidoc_xmlto=no
+
+AS_IF([test "x$man_pages_opt" = "xyes"], [
 	AC_PATH_PROG([ASCIIDOC], [asciidoc], [no])
 	AC_PATH_PROG([XMLTO], [xmlto], [no])
 
 	AS_IF([test "x$ASCIIDOC" = "xno" || test "x$XMLTO" = "xno"], [
-		AC_MSG_ERROR([Both asciidoc and xmlto are needed to build the LTTng man pages.])
+		AS_IF([test "x$in_git_repo" = "xyes"], [
+			# this is an error because we're in the Git repo, which
+			# means the man pages are not already generated for us,
+			# thus asciidoc/xmlto are required because we were asked
+			# to build the man pages
+			AC_MSG_ERROR([
+Both asciidoc and xmlto are needed to build the LTTng man pages. Use
+--disable-man-pages to disable building the man pages, in which case
+they will not be installed.
+			])
+		], [
+			# only warn here: since we're in the tarball, the man
+			# pages should already be generated at this point, thus
+			# asciidoc/xmlto are not strictly required
+			AC_MSG_WARN([
+Both asciidoc and xmlto are needed to build the LTTng man pages. Note
+that the man pages are already built in this distribution tarball, so
+asciidoc and xmlto are only needed if you intend to modify their
+sources. Use --disable-man-pages to completely disable building
+and installing the man pages.
+			])
+		])
+	], [
+		have_asciidoc_xmlto=yes
 	])
 ])
+
+# export man page build condition: build the man pages if the user
+# asked for it, and if the tools are available
+AM_CONDITIONAL([MAN_PAGES_OPT], [test "x$man_pages_opt" != "xno"])
+AM_CONDITIONAL([HAVE_ASCIIDOC_XMLTO], [test "x$have_asciidoc_xmlto" = "xyes"])
 
 # Python agent test
 UST_PYTHON_AGENT="lttngust"
@@ -988,25 +1015,29 @@ test "x${enable_python_binding:-yes}" = xyes && value=1 || value=0
 AS_ECHO
 PPRINT_SET_INDENT(0)
 PPRINT_PROP_BOOL([Python binding], $value, $PPRINT_COLOR_SUBTITLE)
-PPRINT_SET_INDENT(1)
-
-AS_ECHO
-PPRINT_SUBTITLE([Man pages])
 
 # man pages build enabled/disabled
-AS_IF([test "x$build_man_pages" = "xyes"], [
-	PPRINT_PROP_BOOL([Build man pages], 1)
-], [
+m4_pushdef([build_man_pages_msg], [Build and install man pages])
+
+AS_IF([test "x$man_pages_opt" != "xno"], [
 	AS_IF([test "x$in_git_repo" = "xyes"], [
-		PPRINT_PROP_BOOL([Build man pages], 0)
+		PPRINT_PROP_BOOL([build_man_pages_msg], 1, $PPRINT_COLOR_SUBTITLE)
 	], [
-		PPRINT_PROP_STRING([Build man pages], [${PPRINT_COLOR_BLDGRN}Already built])
+		AS_IF([test "x$have_asciidoc_xmlto" = "xyes"], [
+			PPRINT_PROP_BOOL([build_man_pages_msg], 1, $PPRINT_COLOR_SUBTITLE)
+		], [
+			PPRINT_PROP_STRING([build_man_pages_msg],
+				[${PPRINT_COLOR_BLDGRN}yes (already built)],
+				$PPRINT_COLOR_SUBTITLE)
+		])
 	])
+], [
+	PPRINT_PROP_BOOL([build_man_pages_msg], 0, $PPRINT_COLOR_SUBTITLE)
 ])
 
-# man pages install enabled/disabled (always true in tarball)
-test "x$build_man_pages" != "xyes" && test "x$in_git_repo" = "xyes" && value=0 || value=1
-PPRINT_PROP_BOOL([Install man pages], $value)
+m4_popdef([build_man_pages_msg])
+
+PPRINT_SET_INDENT(1)
 
 report_bindir="`eval eval echo $bindir`"
 report_libdir="`eval eval echo $libdir`"

--- a/configure.ac
+++ b/configure.ac
@@ -796,27 +796,49 @@ AM_CONDITIONAL([BUILD_LIB_UST_CONSUMER], [test x$build_lib_ust_consumer = xyes])
 AC_PATH_PROG([PGREP], [pgrep], [no])
 AM_CONDITIONAL([HAS_PGREP], [test "x$PGREP" != "xno"])
 
-if test ! -f "$srcdir/src/lib/lttng-ctl/filter/filter-parser.h"; then
-	if test x"$(basename "$YACC")" != "xbison -y"; then
-		AC_MSG_ERROR([[bison not found and is required when building from git.
-		Please install bison]])
-	fi
-	AC_PATH_PROG([BISON],[bison])
-	AX_PROG_BISON_VERSION([2.4], [],[
-		AC_MSG_ERROR([[Bison >= 2.4 is required when building from git]])
-	])
-fi
+# check for bison
+have_bison=yes
 
-if test ! -f "$srcdir/src/lib/lttng-ctl/filter/filter-lexer.c"; then
-	if test x"$LEX" != "xflex"; then
-		AC_MSG_ERROR([[flex not found and is required when building from git.
-		Please install flex]])
-	fi
-	AC_PATH_PROG([FLEX],[flex])
-	AX_PROG_FLEX_VERSION([2.5.35], [],[
-		AC_MSG_ERROR([[Flex >= 2.5.35 is required when building from git]])
+AS_IF([test "x$(basename "$YACC")" != "xbison -y"], [have_bison=no])
+AC_PATH_PROG([BISON], [bison])
+AX_PROG_BISON_VERSION([2.4], [], [have_bison=no])
+
+AS_IF([test "x$have_bison" = "xno"], [
+	AS_IF([test "x$in_git_repo" = "xyes"], [
+		AC_MSG_ERROR([Bison >= 2.4 is required when building from the Git repository.])
+	], [
+		AC_MSG_WARN([
+Missing Bison >= 2.4. Note that the parser files are already built in
+this distribution tarball, so Bison is only needed if you intend to
+modify their sources.
+		])
 	])
-fi
+])
+
+# export bison condition
+AM_CONDITIONAL([HAVE_BISON], [test "x$have_bison" = "xyes"])
+
+# check for flex
+have_flex=yes
+
+AS_IF([test "x$LEX" != "xflex"], [have_flex=no])
+AC_PATH_PROG([FLEX], [flex])
+AX_PROG_FLEX_VERSION([2.5.35], [], [have_flex=no])
+
+AS_IF([test "x$have_flex" = "xno"], [
+	AS_IF([test "x$in_git_repo" = "xyes"], [
+		AC_MSG_ERROR([Flex >= 2.5.35 is required when building from the Git repository.])
+	], [
+		AC_MSG_WARN([
+Missing Flex >= 2.5.35. Note that the lexer files are already built in
+this distribution tarball, so Flex is only needed if you intend to
+modify their sources.
+		])
+	])
+])
+
+# export flex condition
+AM_CONDITIONAL([HAVE_FLEX], [test "x$have_flex" = "xyes"])
 
 CFLAGS="-Wall $CFLAGS -g -fno-strict-aliasing"
 

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -1,5 +1,5 @@
-# Man pages are only built if the --enable-build-man-pages option was passed
-# to the configure script.
+# Man pages are only built if the --enable-man-pages option was
+# passed to the configure script.
 #
 # They should always be built before creating a distribution tarball.
 
@@ -38,27 +38,6 @@ MAN1_NO_ASCIIDOC_NAMES =
 MAN3_NO_ASCIIDOC_NAMES = lttng-health-check
 MAN8_NO_ASCIIDOC_NAMES =
 
-# man pages destinations
-MAN1 = $(addsuffix .1,$(MAN1_NAMES))
-MAN3 = $(addsuffix .3,$(MAN3_NAMES))
-MAN8 = $(addsuffix .8,$(MAN8_NAMES))
-MAN1_NO_ASCIIDOC = $(addsuffix .1,$(MAN1_NO_ASCIIDOC_NAMES))
-MAN3_NO_ASCIIDOC = $(addsuffix .3,$(MAN3_NO_ASCIIDOC_NAMES))
-MAN8_NO_ASCIIDOC = $(addsuffix .8,$(MAN8_NO_ASCIIDOC_NAMES))
-MAN = $(MAN1) $(MAN3) $(MAN8)
-
-# those are always installed since they are written in troff
-dist_man1_MANS = $(MAN1_NO_ASCIIDOC)
-dist_man3_MANS = $(MAN3_NO_ASCIIDOC)
-dist_man8_MANS = $(MAN8_NO_ASCIIDOC)
-
-# only build man pages if it was enabled
-if BUILD_MAN_PAGES
-# dist + install
-dist_man1_MANS += $(MAN1)
-dist_man3_MANS += $(MAN3)
-dist_man8_MANS += $(MAN8)
-
 # AsciiDoc sources and outputs
 MAN1_TXT = $(call manaddsuffix,.1.txt,$(MAN1_NAMES))
 MAN3_TXT = $(call manaddsuffix,.3.txt,$(MAN3_NAMES))
@@ -85,9 +64,21 @@ XSL_SRC_FILES = $(addprefix $(srcdir)/xsl/,$(XSL_FILES))
 # common dependencies
 COMMON_DEPS = $(ASCIIDOC_CONF) $(COMMON_TXT)
 
+# man pages destinations
+MAN1 = $(addsuffix .1,$(MAN1_NAMES))
+MAN3 = $(addsuffix .3,$(MAN3_NAMES))
+MAN8 = $(addsuffix .8,$(MAN8_NAMES))
+MAN1_NO_ASCIIDOC = $(addsuffix .1,$(MAN1_NO_ASCIIDOC_NAMES))
+MAN3_NO_ASCIIDOC = $(addsuffix .3,$(MAN3_NO_ASCIIDOC_NAMES))
+MAN8_NO_ASCIIDOC = $(addsuffix .8,$(MAN8_NO_ASCIIDOC_NAMES))
+MAN = $(MAN1) $(MAN3) $(MAN8)
+
+if MAN_PAGES_OPT
+# at this point, we know the user asked to build the man pages
+if HAVE_ASCIIDOC_XMLTO
 # tools
 ADOC = $(ASCIIDOC) -f $(ASCIIDOC_CONF) -d manpage \
-	-a lttng_version=$(PACKAGE_VERSION)
+	-a lttng_version="$(PACKAGE_VERSION)"
 ADOC_DOCBOOK = $(ADOC) -b docbook
 XTO = $(XMLTO) -m $(firstword $(XSL_SRC_FILES)) man
 
@@ -110,21 +101,39 @@ XTO = $(XMLTO) -m $(firstword $(XSL_SRC_FILES)) man
 %.8: %.8.xml $(XSL_SRC_FILES)
 	$(XTO) $<
 
-clean-local:
-	rm -rf $(MAN_XML)
-	rm -rf $(MAN)
-else
-if IN_GIT_REPO
-# we are in the Git repo: the man pages should be built for distribution
-dist-hook:
-	@echo
-	@echo 'Error: Please build the man pages before creating a tarball.'
-	@echo
+# only clean the generated files if we have the tools to generate them again
+CLEANFILES = $(MAN_XML) $(MAN)
+else # HAVE_ASCIIDOC_XMLTO
+# create man page targets used to stop the build if we want to
+# build the man pages, but we don't have the necessary tools to do so
+ERR_MSG = "Error: Cannot build target because asciidoc or xmlto tool is missing."
+ERR_MSG += "Make sure both tools are installed and run the configure script again."
+
+%.1: $(srcdir)/%.1.txt $(COMMON_DEPS)
+	@echo $(ERR_MSG)
 	@false
-else
-# we are in the tarball, hence the man pages are already built
+
+%.3: $(srcdir)/%.3.txt $(COMMON_DEPS)
+	@echo $(ERR_MSG)
+	@false
+
+%.8: $(srcdir)/%.8.txt $(COMMON_DEPS)
+	@echo $(ERR_MSG)
+	@false
+endif # HAVE_ASCIIDOC_XMLTO
+endif # MAN_PAGES_OPT
+
+# those are always installed since they are directly written in troff
+dist_man1_MANS = $(MAN1_NO_ASCIIDOC)
+dist_man3_MANS = $(MAN3_NO_ASCIIDOC)
+dist_man8_MANS = $(MAN8_NO_ASCIIDOC)
+
+if MAN_PAGES_OPT
+# building man pages: we can install and distribute them
 dist_man1_MANS += $(MAN1)
 dist_man3_MANS += $(MAN3)
 dist_man8_MANS += $(MAN8)
-endif # IN_GIT_REPO
-endif # BUILD_MAN_PAGES
+endif # MAN_PAGES_OPT
+
+# always distribute the source files
+EXTRA_DIST = $(MAN_TXT) $(COMMON_TXT) $(XSL_SRC_FILES) $(ASCIIDOC_CONF)

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -1,5 +1,4 @@
-# Man pages are only built if the --enable-man-pages option was
-# passed to the configure script.
+# Man pages are only built if they are enabled at configure time.
 #
 # They should always be built before creating a distribution tarball.
 

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -134,5 +134,11 @@ dist_man3_MANS += $(MAN3)
 dist_man8_MANS += $(MAN8)
 endif # MAN_PAGES_OPT
 
+if !MAN_PAGES_OPT
+dist-hook:
+	@echo "Error: Please enable the man pages before creating a distribution tarball."
+	@false
+endif # !MAN_PAGES_OPT
+
 # always distribute the source files
 EXTRA_DIST = $(MAN_TXT) $(COMMON_TXT) $(XSL_SRC_FILES) $(ASCIIDOC_CONF)

--- a/doc/man/README.md
+++ b/doc/man/README.md
@@ -23,13 +23,12 @@ AsciiDoc is configured with `asciidoc.conf` which contains a few
 macro definitions used everywhere in the man page sources.
 
 
-### linklttng
+### man
 
-The linklttng macro is used to link to another LTTng man page. Its
-output is different depending on the back-end. In troff, the man page
-name is rendered in bold, whereas the HTML5 output renders a hyperlink.
+The man macro is used to link to another man page. In troff, the man
+page name is rendered in bold.
 
-Usage example: `linklttng:lttng-enable-channel(1)`.
+Usage example: `man:lttng-enable-channel(1)`.
 
 
 ### linkgenoptions

--- a/doc/man/asciidoc.conf
+++ b/doc/man/asciidoc.conf
@@ -1,12 +1,12 @@
 [macros]
 
-# linklttng macro
+# man macro
 #
 # Inspired by linkgit macro:
 # <https://github.com/git/git/blob/master/Documentation/asciidoc.conf>
 #
-# Usage: linklttng:command(manpage-section)
-(?su)[\\]?(?P<name>linklttng):(?P<target>\S*?)\((?P<attrlist>.*?)\)=
+# Usage: man:command(manpage-section)
+(?su)[\\]?(?P<name>man):(?P<target>\S*?)\((?P<attrlist>.*?)\)=
 
 # linkgenoptions macro
 #
@@ -38,9 +38,9 @@
 # Usage: :escwc:
 :escwc:=escwc
 
-# linklttng macro expansions
+# man macro expansions
 ifdef::backend-docbook[]
-[linklttng-inlinemacro]
+[man-inlinemacro]
 {0%{target}}
 {0#<citerefentry>}
 {0#<refentrytitle>{target}</refentrytitle><manvolnum>{0}</manvolnum>}

--- a/doc/man/asciidoc.conf
+++ b/doc/man/asciidoc.conf
@@ -39,6 +39,7 @@
 :escwc:=escwc
 
 # man macro expansions
+ifdef::doctype-manpage[]
 ifdef::backend-docbook[]
 [man-inlinemacro]
 {0%{target}}
@@ -46,42 +47,55 @@ ifdef::backend-docbook[]
 {0#<refentrytitle>{target}</refentrytitle><manvolnum>{0}</manvolnum>}
 {0#</citerefentry>}
 endif::backend-docbook[]
+endif::doctype-manpage[]
 
 # linkgenoptions macro expansions
+ifdef::doctype-manpage[]
 ifdef::backend-docbook[]
 [linkgenoptions-inlinemacro]
 {text}
 endif::backend-docbook[]
+endif::doctype-manpage[]
 
 # option macro expansions
+ifdef::doctype-manpage[]
 ifdef::backend-docbook[]
 [option-inlinemacro]
 <literal>{opt}</literal>
 endif::backend-docbook[]
+endif::doctype-manpage[]
 
 # no link option macro expansions
+ifdef::doctype-manpage[]
 ifdef::backend-docbook[]
 [nloption-inlinemacro]
 <literal>{opt}</literal>
 endif::backend-docbook[]
+endif::doctype-manpage[]
 
 # lttng(1) general option macro expansions
+ifdef::doctype-manpage[]
 ifdef::backend-docbook[]
 [genoption-inlinemacro]
 <literal>{opt}</literal>
 endif::backend-docbook[]
+endif::doctype-manpage[]
 
 # not macro expansions
+ifdef::doctype-manpage[]
 ifdef::backend-docbook[]
 [not-inlinemacro]
 NOT
 endif::backend-docbook[]
+endif::doctype-manpage[]
 
 # escwc macro expansions
+ifdef::doctype-manpage[]
 ifdef::backend-docbook[]
 [escwc-inlinemacro]
 <literal>\e*</literal>
 endif::backend-docbook[]
+endif::doctype-manpage[]
 
 # configure XML man page header
 ifdef::doctype-manpage[]

--- a/doc/man/common-cmd-footer.txt
+++ b/doc/man/common-cmd-footer.txt
@@ -6,7 +6,7 @@ ENVIRONMENT VARIABLES
 
 `LTTNG_MAN_BIN_PATH`::
     Absolute path to the man pager to use for viewing help information
-    about LTTng commands (using linklttng:lttng-help(1) or
+    about LTTng commands (using man:lttng-help(1) or
     `lttng COMMAND --help`).
 
 `LTTNG_SESSION_CONFIG_XSD_PATH`::
@@ -19,9 +19,9 @@ ENVIRONMENT VARIABLES
 The genoption:--sessiond-path option has precedence over this
 environment variable.
 
-Note that the linklttng:lttng-create(1) command can spawn an LTTng
+Note that the man:lttng-create(1) command can spawn an LTTng
 session daemon automatically if none is running. See
-linklttng:lttng-sessiond(8) for the environment variables influencing
+man:lttng-sessiond(8) for the environment variables influencing
 the execution of the session daemon.
 
 

--- a/doc/man/common-cmd-help-options.txt
+++ b/doc/man/common-cmd-help-options.txt
@@ -3,7 +3,7 @@ Program information
 option:-h, option:--help::
     Show command help.
 +
-This option, like linklttng:lttng-help(1), attempts to launch
+This option, like man:lttng-help(1), attempts to launch
 `/usr/bin/man` to view the command's man page. The path to the man pager
 can be overridden by the `LTTNG_MAN_BIN_PATH` environment variable.
 

--- a/doc/man/common-cmd-options-head.txt
+++ b/doc/man/common-cmd-options-head.txt
@@ -1,3 +1,3 @@
 OPTIONS
 -------
-linkgenoptions:(General options) are described in linklttng:lttng(1).
+linkgenoptions:(General options) are described in man:lttng(1).

--- a/doc/man/lttng-add-context.1.txt
+++ b/doc/man/lttng-add-context.1.txt
@@ -28,7 +28,7 @@ DESCRIPTION
 The `lttng add-context` command adds one or more context fields to a
 channel.
 
-Channels are created with the linklttng:lttng-enable-channel(1) command.
+Channels are created with the man:lttng-enable-channel(1) command.
 
 When context fields are added to a channel, all the events emitted
 within this channel contain the dynamic values of those context fields.
@@ -116,4 +116,4 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng(1)
+man:lttng(1)

--- a/doc/man/lttng-calibrate.1.txt
+++ b/doc/man/lttng-calibrate.1.txt
@@ -56,7 +56,7 @@ lttng destroy
 babeltrace $(ls -1drt ~/lttng-traces/calibrate-function-* | tail -n 1)
 ------------------------------------------------------------------------
 
-The output from linklttng:babeltrace(1) can be saved to a text file and
+The output from man:babeltrace(1) can be saved to a text file and
 opened in a spreadsheet (for example, in LibreOffice) to focus on the
 per-PMU counter delta between consecutive `calibrate_entry` and
 `calibrate_return` events. Note that these counters are per-CPU, so
@@ -113,4 +113,4 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng(1)
+man:lttng(1)

--- a/doc/man/lttng-crash.1.txt
+++ b/doc/man/lttng-crash.1.txt
@@ -74,8 +74,8 @@ include::common-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng(1),
-linklttng:lttng-sessiond(8),
-linklttng:lttng-relayd(8),
-linklttng:lttng-ust(3),
-linklttng:babeltrace(1)
+man:lttng(1),
+man:lttng-sessiond(8),
+man:lttng-relayd(8),
+man:lttng-ust(3),
+man:babeltrace(1)

--- a/doc/man/lttng-create.1.txt
+++ b/doc/man/lttng-create.1.txt
@@ -43,7 +43,7 @@ On execution, an `.lttngrc` file is created, if it does not exist, in the
 user's home directory. This file contains the name of the current tracing
 session. When creating a new tracing session with `lttng create`, the
 current tracing session is set to this new tracing session. The
-linklttng:lttng-set-session(1) command can be used to set the current
+man:lttng-set-session(1) command can be used to set the current
 tracing session without manually editing the `.lttngrc` file.
 
 If 'SESSION' is omitted, a session name is automatically created having
@@ -55,9 +55,9 @@ shared memory holding the ring buffers. Specifying a location on an
 NVRAM file system makes it possible to retrieve the latest recorded
 trace data when the system reboots after a crash. To view the events
 of ring buffer files after a system crash, use the
-linklttng:lttng-crash(1) utility.
+man:lttng-crash(1) utility.
 
-Tracing sessions are destroyed using the linklttng:lttng-destroy(1)
+Tracing sessions are destroyed using the man:lttng-destroy(1)
 command.
 
 
@@ -76,14 +76,14 @@ Snapshot mode::
     Traces the local system without writing the trace to the local file
     system (implicit option:--no-output option). Channels are automatically
     configured to be snapshot-ready on creation (see
-    linklttng:lttng-enable-channel(1)). The linklttng:lttng-snapshot(1)
+    man:lttng-enable-channel(1)). The man:lttng-snapshot(1)
     command is used to take snapshots of the current ring buffers.
     The option:--set-url, or option:--ctrl-url and option:--data-url
     options set the default snapshot output destination.
 
 Live mode::
     Traces the local system, sending trace data to an LTTng relay daemon
-    over the network (see linklttng:lttng-relayd(8)). The
+    over the network (see man:lttng-relayd(8)). The
     option:--set-url, or option:--ctrl-url and option:--data-url options
     set the trace output destination. The live output URLs cannot use
     the `file://` protocol (see URL format below).
@@ -132,7 +132,7 @@ The other version is used for *network streaming*.
 'TRACEPATH'::
     Path of trace files on the remote file system. This path is relative
     to the base output directory set on the relay daemon side;
-    see linklttng:lttng-relayd(8).
+    see man:lttng-relayd(8).
 
 
 include::common-cmd-options-head.txt[]
@@ -145,7 +145,7 @@ option:--live[='DELAYUS']::
     given in microseconds, is the maximum time the user can wait for
     the data to be flushed. This mode can be set with a network URL
     (options option:--set-url, or option:--ctrl-url and option:--data-url)
-    and must have a relay daemon listening (see linklttng:lttng-relayd(8)).
+    and must have a relay daemon listening (see man:lttng-relayd(8)).
 +
 By default, 'DELAYUS' is 1000000 and the network URL is set to
 `net://127.0.0.1`.
@@ -196,6 +196,6 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-destroy(1),
-linklttng:lttng-set-session(1),
-linklttng:lttng(1)
+man:lttng-destroy(1),
+man:lttng-set-session(1),
+man:lttng(1)

--- a/doc/man/lttng-destroy.1.txt
+++ b/doc/man/lttng-destroy.1.txt
@@ -18,12 +18,12 @@ DESCRIPTION
 The `lttng destroy` command destroys one or more tracing sessions.
 
 If no options are specified, the current tracing session is destroyed
-(see linklttng:lttng-create(1) for more information about the current
+(see man:lttng-create(1) for more information about the current
 tracing session).
 
 If 'SESSION' is specified, the existing tracing session named 'SESSION'
 is destroyed. `lttng list` outputs all the existing tracing sessions
-(see linklttng:lttng-list(1)).
+(see man:lttng-list(1)).
 
 If the option:--all option is used, *all* the tracing sessions, as listed
 in the output of `lttng list`, are destroyed.
@@ -50,6 +50,6 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-create(1),
-linklttng:lttng-set-session(1),
-linklttng:lttng(1)
+man:lttng-create(1),
+man:lttng-set-session(1),
+man:lttng(1)

--- a/doc/man/lttng-disable-channel.1.txt
+++ b/doc/man/lttng-disable-channel.1.txt
@@ -17,10 +17,10 @@ SYNOPSIS
 DESCRIPTION
 -----------
 The `lttng disable-channel` command disables one or more channels
-previously enabled by the linklttng:lttng-enable-channel(1) command.
+previously enabled by the man:lttng-enable-channel(1) command.
 
 A channel is always contained in a tracing session
-(see linklttng:lttng-create(1) for creating a tracing session). The
+(see man:lttng-create(1) for creating a tracing session). The
 session in which a channel is disabled using `lttng disable-channel` can
 be specified using the option:--session option. If the option:--session
 option is omitted, the current tracing session is targeted.
@@ -58,5 +58,5 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-disable-channel(1),
-linklttng:lttng(1)
+man:lttng-disable-channel(1),
+man:lttng(1)

--- a/doc/man/lttng-disable-event.1.txt
+++ b/doc/man/lttng-disable-event.1.txt
@@ -19,7 +19,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 The `lttng disable-event` command disables one or more event rules
-previously enabled by the linklttng:lttng-enable-event(1) command.
+previously enabled by the man:lttng-enable-event(1) command.
 
 Event rules are always assigned to a channel when they are created. If
 the option:--channel option is omitted, the default channel named
@@ -35,11 +35,11 @@ to disable named 'EVENT' must be specified.
 With the option:--kernel option, the event source type can be specified
 using one of the option:--tracepoint, option:--probe,
 option:--function, or option:--syscall options. See
-linklttng:lttng-enable-event(1) for more details about event source
+man:lttng-enable-event(1) for more details about event source
 types.
 
 Events can be disabled while tracing is active
-(use linklttng:lttng-start(1) to make a tracing session active).
+(use man:lttng-start(1) to make a tracing session active).
 
 
 include::common-cmd-options-head.txt[]
@@ -112,5 +112,5 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-enable-event(1),
-linklttng:lttng(1)
+man:lttng-enable-event(1),
+man:lttng(1)

--- a/doc/man/lttng-enable-channel.1.txt
+++ b/doc/man/lttng-enable-channel.1.txt
@@ -42,7 +42,7 @@ The `lttng enable-channel` command can create a new channel, or enable
 one or more existing and disabled ones.
 
 A channel is the owner of sub-buffers holding recorded events. Event,
-rules, when created using linklttng:lttng-enable-event(1), are always
+rules, when created using man:lttng-enable-event(1), are always
 assigned to a channel. When creating a new channel, many parameters
 related to those sub-buffers can be fine-tuned. They are described in
 the subsections below.
@@ -51,18 +51,18 @@ When 'CHANNEL' does not name an existing channel, a channel named
 'CHANNEL' is created. Otherwise, the disabled channel named 'CHANNEL'
 is enabled.
 
-Note that the linklttng:lttng-enable-event(1) command can automatically
+Note that the man:lttng-enable-event(1) command can automatically
 create default channels when no channel exist.
 
 A channel is always contained in a tracing session
-(see linklttng:lttng-create(1) for creating a tracing session). The
+(see man:lttng-create(1) for creating a tracing session). The
 session in which a channel is created using `lttng enable-channel` can
 be specified using the option:--session option. If the option:--session
 option is omitted, the current tracing session is targeted.
 
 Existing enabled channels can be disabled using
-linklttng:lttng-disable-channel(1). Channels of a given session can be
-listed using linklttng:lttng-list(1).
+man:lttng-disable-channel(1). Channels of a given session can be
+listed using man:lttng-list(1).
 
 See the <<limitations,LIMITATIONS>> section below for a list of
 limitations of this command to consider.
@@ -366,5 +366,5 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-disable-channel(1),
-linklttng:lttng(1)
+man:lttng-disable-channel(1),
+man:lttng(1)

--- a/doc/man/lttng-enable-event.1.txt
+++ b/doc/man/lttng-enable-event.1.txt
@@ -42,9 +42,9 @@ An event rule created by `lttng enable-event` is a set of conditions
 that must be satisfied in order for an actual event to be emitted by
 an LTTng tracer when the execution of an application or the Linux kernel
 reaches an event source (tracepoint, system call, dynamic probe).
-Event sources can be listed with the linklttng:lttng-list(1) command.
+Event sources can be listed with the man:lttng-list(1) command.
 
-The linklttng:lttng-disable-event(1) command can be used to disable
+The man:lttng-disable-event(1) command can be used to disable
 existing event rules.
 
 Event rules are always assigned to a channel when they are created. If
@@ -56,7 +56,7 @@ If the option:--session option is omitted, the chosen channel is picked
 from the current tracing session.
 
 Events can be enabled while tracing is active
-(use linklttng:lttng-start(1) to make a tracing session active).
+(use man:lttng-start(1) to make a tracing session active).
 
 
 Event source types
@@ -163,7 +163,7 @@ When using `lttng enable-event` with a set of conditions that does not
 currently exist for the chosen tracing session, domain, and channel,
 a new event rule is created. Otherwise, the existing event rule is
 enabled if it is currently disabled
-(see linklttng:lttng-disable-event(1)).
+(see man:lttng-disable-event(1)).
 
 The option:--all option can be used alongside the option:--tracepoint
 or option:--syscall options. When this option is used, no 'EVENT'
@@ -222,11 +222,11 @@ a C identifier.
 The dynamic value of a statically-known context field is read by
 prefixing its name with `$ctx.`. Statically-known context fields are
 context fields added to channels without the `$app.` prefix using the
-linklttng:lttng-add-context(1) command.
+man:lttng-add-context(1) command.
 
 The dynamic value of an application-specific context field is read by
 prefixing its name with `$app.` (follows the format used to add such a
-context field with the linklttng:lttng-add-context(1) command).
+context field with the man:lttng-add-context(1) command).
 
 When a comparison includes a non existent event field, the whole filter
 expression evaluates to false (the event is discarded).
@@ -242,7 +242,7 @@ or constants).
 NOTE: Although it is possible to filter the process ID of an event when
 the `pid` context has been added to its channel using, for example,
 `$ctx.pid == 2832`, it is recommended to use the PID tracker instead,
-which is much more efficient (see linklttng:lttng-track(1)).
+which is much more efficient (see man:lttng-track(1)).
 
 Examples:
 
@@ -437,5 +437,5 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-disable-event(1),
-linklttng:lttng(1)
+man:lttng-disable-event(1),
+man:lttng(1)

--- a/doc/man/lttng-help.1.txt
+++ b/doc/man/lttng-help.1.txt
@@ -27,7 +27,7 @@ lttng COMMAND --help
 
 where `COMMAND` is the name of the command about which to get help. If
 'COMMAND' is omitted, `lttng help` shows general help about the
-linklttng:lttng(1) command.
+man:lttng(1) command.
 
 The `lttng help` command attempts to launch `/usr/bin/man` to view
 the command's man page. The path to the man pager can be overridden
@@ -45,4 +45,4 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng(1)
+man:lttng(1)

--- a/doc/man/lttng-list.1.txt
+++ b/doc/man/lttng-list.1.txt
@@ -107,4 +107,4 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng(1)
+man:lttng(1)

--- a/doc/man/lttng-load.1.txt
+++ b/doc/man/lttng-load.1.txt
@@ -19,7 +19,7 @@ The `lttng load` command loads the configurations of one or more
 tracing sessions from files.
 
 The `lttng load` command is used in conjunction with the
-linklttng:lttng-save(1) command to save and restore the complete
+man:lttng-save(1) command to save and restore the complete
 configurations of tracing sessions. This includes the enabled channels
 and event rules, the context added to channels, the tracing activity,
 and more.
@@ -69,5 +69,5 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-save(1),
-linklttng:lttng(1)
+man:lttng-save(1),
+man:lttng(1)

--- a/doc/man/lttng-metadata.1.txt
+++ b/doc/man/lttng-metadata.1.txt
@@ -49,8 +49,8 @@ The `lttng metadata regenerate` command can only be used on kernel and
 user space tracing sessions (using per-user buffering), in non-live
 mode.
 
-See linklttng:lttng-enable-channel(1) for more information about
-buffering schemes and linklttng:lttng-create(1) for more information
+See man:lttng-enable-channel(1) for more information about
+buffering schemes and man:lttng-create(1) for more information
 about the different tracing session modes.
 
 
@@ -59,4 +59,4 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng(1)
+man:lttng(1)

--- a/doc/man/lttng-relayd.8.txt
+++ b/doc/man/lttng-relayd.8.txt
@@ -186,8 +186,8 @@ include::common-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng(1),
-linklttng:lttng-sessiond(8),
-linklttng:lttng-crash(1),
-linklttng:lttng-ust(3),
-linklttng:babeltrace(1)
+man:lttng(1),
+man:lttng-sessiond(8),
+man:lttng-crash(1),
+man:lttng-ust(3),
+man:babeltrace(1)

--- a/doc/man/lttng-save.1.txt
+++ b/doc/man/lttng-save.1.txt
@@ -19,7 +19,7 @@ The `lttng save` command saves the configurations of one or more
 tracing sessions to files.
 
 The `lttng save` command is used in conjunction with the
-linklttng:lttng-load(1) command to save and restore the complete
+man:lttng-load(1) command to save and restore the complete
 configurations of tracing sessions. This includes the enabled channels
 and event rules, the context added to channels, the tracing activity,
 and more. `lttng save` does not save tracing data, only the tracing
@@ -28,7 +28,7 @@ session parameters.
 If 'SESSION' is omitted, all the existing tracing session configurations
 are saved (equivalent to using the option:--all option). Otherwise,
 'SESSION' is the name of an existing tracing session. `lttng list`
-outputs all the existing tracing sessions (see linklttng:lttng-list(1)).
+outputs all the existing tracing sessions (see man:lttng-list(1)).
 
 The default output directory path is `$LTTNG_HOME/.lttng/sessions`
 (`$LTTNG_HOME` defaults to `$HOME`). Each tracing session configuration
@@ -63,5 +63,5 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-load(1),
-linklttng:lttng(1)
+man:lttng-load(1),
+man:lttng(1)

--- a/doc/man/lttng-sessiond.8.txt
+++ b/doc/man/lttng-sessiond.8.txt
@@ -40,8 +40,8 @@ The _LTTng session daemon_ is a tracing registry which allows the user
 to interact with multiple tracers (kernel and user space) within the
 same container, a _tracing session_. Traces can be gathered from the
 Linux kernel and/or from instrumented applications (see
-linklttng:lttng-ust(3)). You can aggregate and read the events of LTTng
-traces using linklttng:babeltrace(1).
+man:lttng-ust(3)). You can aggregate and read the events of LTTng
+traces using man:babeltrace(1).
 
 To trace the Linux kernel, the session daemon needs to be running as
 `root`. LTTng uses a _tracing group_ to allow specific users to interact
@@ -102,7 +102,7 @@ option:-l, option:--load='PATH'::
 option:-S, option:--sig-parent::
     Send `SIGUSR1` to parent process to notify readiness.
 +
-NOTE: This is used by linklttng:lttng(1) to get notified when the
+NOTE: This is used by man:lttng(1) to get notified when the
 session daemon is ready to accept commands. When building a third party
 tool on liblttng-ctl, this option can be very handy to synchronize the
 control tool and the session daemon.
@@ -290,8 +290,8 @@ include::common-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng(1),
-linklttng:lttng-relayd(8),
-linklttng:lttng-crash(1),
-linklttng:lttng-ust(3),
-linklttng:babeltrace(1)
+man:lttng(1),
+man:lttng-relayd(8),
+man:lttng-crash(1),
+man:lttng-ust(3),
+man:babeltrace(1)

--- a/doc/man/lttng-set-session.1.txt
+++ b/doc/man/lttng-set-session.1.txt
@@ -18,10 +18,10 @@ DESCRIPTION
 The `lttng set-session` command sets the current tracing session.
 
 'SESSION' is the name of an existing tracing session. `lttng list`
-outputs all the existing tracing sessions (see linklttng:lttng-list(1)).
+outputs all the existing tracing sessions (see man:lttng-list(1)).
 
 The current tracing session is used by default when a session can be
-specified in other commands. See linklttng:lttng-create(1) for more
+specified in other commands. See man:lttng-create(1) for more
 information about the current tracing session.
 
 
@@ -36,6 +36,6 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-create(1),
-linklttng:lttng-destroy(1),
-linklttng:lttng(1)
+man:lttng-create(1),
+man:lttng-destroy(1),
+man:lttng(1)

--- a/doc/man/lttng-snapshot.1.txt
+++ b/doc/man/lttng-snapshot.1.txt
@@ -46,7 +46,7 @@ is sent to the registered snapshot outputs.
 
 The tracing session should be created in _snapshot mode_ to make sure
 taking snapshots is allowed. This is done at tracing session creation
-time using the linklttng:lttng-create(1) command.
+time using the man:lttng-create(1) command.
 
 Note that, when a snapshot is taken, the sub-buffers are not cleared.
 This means that different recorded snapshots may contain the same
@@ -63,7 +63,7 @@ As of this version, only one snapshot output is allowed.
 A snapshot output can be added using the `add-output` action. The
 output destination URL is set using either the 'URL' positional
 argument, or both the option:--ctrl-url and option:--data-url options.
-See linklttng:lttng-create(1) to learn more about the URL format.
+See man:lttng-create(1) to learn more about the URL format.
 
 A name can be assigned to an output when adding it using the
 option:--name option. This name is part of the names of the
@@ -95,10 +95,10 @@ options supported by the `add-output` action.
 
 NOTE: Before taking a snapshot on a system with a high event throughput,
 it is recommended to first run `lttng stop` (see
-linklttng:lttng-stop(1)). Otherwise, the snapshot could contain "holes",
+man:lttng-stop(1)). Otherwise, the snapshot could contain "holes",
 the result of the tracers overwriting unconsumed trace packets during
 the record operation. After the snapshot is recorded, the tracers can be
-started again with `lttng start` (see linklttng:lttng-start(1)).
+started again with `lttng start` (see man:lttng-start(1)).
 
 
 include::common-cmd-options-head.txt[]
@@ -139,4 +139,4 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng(1)
+man:lttng(1)

--- a/doc/man/lttng-start.1.txt
+++ b/doc/man/lttng-start.1.txt
@@ -23,17 +23,17 @@ within enabled channels can make their target event sources _emit_ trace
 events. Whether they are recorded to the local file system, sent over
 the network, or not recorded at all depends on the specific
 configuration of the tracing session in which tracing is started. See
-linklttng:lttng-create(1) for different session modes.
+man:lttng-create(1) for different session modes.
 
 A tracing session with running tracers is said to be _active_. Active
 tracing sessions can return to the inactive state using the
-linklttng:lttng-stop(1) command.
+man:lttng-stop(1) command.
 
 If 'SESSION' is omitted, the LTTng tracers are started for the current
-tracing session (see linklttng:lttng-create(1) for more information
+tracing session (see man:lttng-create(1) for more information
 about the current tracing session). Otherwise, they are started for the
 existing tracing session named 'SESSION'. `lttng list`
-outputs all the existing tracing sessions (see linklttng:lttng-list(1)).
+outputs all the existing tracing sessions (see man:lttng-list(1)).
 
 
 include::common-cmd-options-head.txt[]
@@ -47,5 +47,5 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-stop(1),
-linklttng:lttng(1)
+man:lttng-stop(1),
+man:lttng(1)

--- a/doc/man/lttng-status.1.txt
+++ b/doc/man/lttng-status.1.txt
@@ -26,7 +26,7 @@ lttng list CURSESSION
 ---------------------
 
 where `CURSESSION` is the name of the current tracing session.
-Use linklttng:lttng-set-session(1) to set the current tracing session.
+Use man:lttng-set-session(1) to set the current tracing session.
 
 
 include::common-cmd-options-head.txt[]
@@ -40,5 +40,5 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-set-session(1),
-linklttng:lttng(1)
+man:lttng-set-session(1),
+man:lttng(1)

--- a/doc/man/lttng-stop.1.txt
+++ b/doc/man/lttng-stop.1.txt
@@ -24,13 +24,13 @@ anymore.
 
 A tracing session with no running tracers is said to be _inactive_.
 Inactive tracing sessions can be set active using the
-linklttng:lttng-start(1) command.
+man:lttng-start(1) command.
 
 If 'SESSION' is omitted, the LTTng tracers are stopped for the current
-tracing session (see linklttng:lttng-create(1) for more information
+tracing session (see man:lttng-create(1) for more information
 about the current tracing session). Otherwise, they are stopped for the
 existing tracing session named 'SESSION'. `lttng list`
-outputs all the existing tracing sessions (see linklttng:lttng-list(1)).
+outputs all the existing tracing sessions (see man:lttng-list(1)).
 
 By default, the `lttng stop` command ensures that the tracing session's
 trace data is valid before returning to the prompt. With the
@@ -55,5 +55,5 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-start(1),
-linklttng:lttng(1)
+man:lttng-start(1),
+man:lttng(1)

--- a/doc/man/lttng-track.1.txt
+++ b/doc/man/lttng-track.1.txt
@@ -21,10 +21,10 @@ resource tracker.
 
 A resource tracker is a _whitelist_ of resources. Tracked resources are
 allowed to emit events, provided those events are targeted by enabled
-event rules (see linklttng:lttng-enable-event(1)).
+event rules (see man:lttng-enable-event(1)).
 
 Tracker entries can be removed from the whitelist with
-linklttng:lttng-untrack(1).
+man:lttng-untrack(1).
 
 As of this version, the only available tracker is the *PID tracker*. The
 process ID (PID) tracker follows one or more process IDs; only the
@@ -102,7 +102,7 @@ It should be noted that the PID tracker tracks the numeric process IDs.
 Should a process with a given ID exit and another process be given this
 ID, then the latter would also be allowed to emit events.
 
-See the linklttng:lttng-untrack(1) for more details about removing
+See the man:lttng-untrack(1) for more details about removing
 entries.
 
 
@@ -148,5 +148,5 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-untrack(1),
-linklttng:lttng(1)
+man:lttng-untrack(1),
+man:lttng(1)

--- a/doc/man/lttng-untrack.1.txt
+++ b/doc/man/lttng-untrack.1.txt
@@ -19,11 +19,11 @@ DESCRIPTION
 The `lttng untrack` commands removes one or more entries from a
 resource tracker.
 
-See linklttng:lttng-track(1) to learn more about LTTng trackers.
+See man:lttng-track(1) to learn more about LTTng trackers.
 
 The untrack command removes specific resources from a tracker. The
 resources to remove must have been precedently added by
-linklttng:lttng-track(1). It is also possible to remove all the
+man:lttng-track(1). It is also possible to remove all the
 resources from the whitelist using the option:--all option.
 
 As of this version, the only available tracker is the PID tracker.
@@ -32,7 +32,7 @@ As of this version, the only available tracker is the PID tracker.
 Example
 ~~~~~~~
 One common operation is to create a tracing session
-(see linklttng:lttng-create(1)), remove all the entries from the PID
+(see man:lttng-create(1)), remove all the entries from the PID
 tracker whitelist, start tracing, and then manually track PIDs
 while tracing is active.
 
@@ -136,5 +136,5 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-track(1),
-linklttng:lttng(1)
+man:lttng-track(1),
+man:lttng(1)

--- a/doc/man/lttng-version.1.txt
+++ b/doc/man/lttng-version.1.txt
@@ -37,4 +37,4 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng(1)
+man:lttng(1)

--- a/doc/man/lttng-view.1.txt
+++ b/doc/man/lttng-view.1.txt
@@ -19,12 +19,12 @@ The `lttng view` command launches an external trace viewer to view the
 current trace of a tracing session.
 
 If 'SESSION' is omitted, the viewer is launched for the current tracing
-session (see linklttng:lttng-create(1) for more information
+session (see man:lttng-create(1) for more information
 about the current tracing session). Otherwise, it is launched for the
 existing tracing session named 'SESSION'. `lttng list`
-outputs all the existing tracing sessions (see linklttng:lttng-list(1)).
+outputs all the existing tracing sessions (see man:lttng-list(1)).
 
-By default, the linklttng:babeltrace(1) trace viewer is launched.
+By default, the man:babeltrace(1) trace viewer is launched.
 Another trace viewer command can be specified using the
 option:--viewer option.
 
@@ -52,4 +52,4 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng(1)
+man:lttng(1)

--- a/doc/man/lttng.1.txt
+++ b/doc/man/lttng.1.txt
@@ -23,7 +23,7 @@ user applications, and user libraries.
 LTTng consists of Linux kernel modules (for Linux kernel tracing) and
 dynamically loaded libraries (for user application and library tracing).
 
-An LTTng _session daemon_, linklttng:lttng-sessiond(8), receives
+An LTTng _session daemon_, man:lttng-sessiond(8), receives
 commands from the command-line interface `lttng` to control the LTTng
 tracers. All interactions with the LTTng tracers happen through the
 `lttng` tool or through the liblttng-ctl library shipped with the
@@ -48,14 +48,14 @@ nloption:-p, nloption:--python::
 
 nloption:-u, nloption:--userspace::
     Apply command to the user space domain (application using
-    liblttng-ust directly; see linklttng:lttng-ust(3)).
+    liblttng-ust directly; see man:lttng-ust(3)).
 
 The LTTng session daemon is a tracing registry which allows the user to
 interact with multiple tracers (kernel and user space) within the same
 container, a _tracing session_. Traces can be gathered from the Linux
 kernel and/or from instrumented applications (see
-linklttng:lttng-ust(3)). You can aggregate and read the events of LTTng
-traces using linklttng:babeltrace(1).
+man:lttng-ust(3)). You can aggregate and read the events of LTTng
+traces using man:babeltrace(1).
 
 To trace the Linux kernel, the session daemon needs to be running as
 `root`. LTTng uses a _tracing group_ to allow specific users to interact
@@ -73,9 +73,9 @@ for stable and long-term tracing.
 User applications instrumented with LTTng automatically register to the
 root session daemon and to user session daemons. This allows any session
 daemon to list the available traceable applications and event sources
-(see linklttng:lttng-list(1)).
+(see man:lttng-list(1)).
 
-By default, the linklttng:lttng-create(1) command automatically spawns a
+By default, the man:lttng-create(1) command automatically spawns a
 user session daemon if none is currently running. The
 option:--no-sessiond general option can be set to avoid this.
 
@@ -147,88 +147,88 @@ The following commands also have their own nloption:--help option.
 
 Tracing sessions
 ~~~~~~~~~~~~~~~~
-linklttng:lttng-create(1)::
+man:lttng-create(1)::
     Create a tracing session.
 
-linklttng:lttng-destroy(1)::
+man:lttng-destroy(1)::
     Tear down tracing sessions.
 
-linklttng:lttng-load(1)::
+man:lttng-load(1)::
     Load tracing session configurations.
 
-linklttng:lttng-metadata(1)::
+man:lttng-metadata(1)::
     Manage an LTTng tracing session's metadata generation.
 
-linklttng:lttng-save(1)::
+man:lttng-save(1)::
     Save tracing session configurations.
 
-linklttng:lttng-set-session(1)::
+man:lttng-set-session(1)::
     Set current tracing session.
 
 
 Channels
 ~~~~~~~~
-linklttng:lttng-add-context(1)::
+man:lttng-add-context(1)::
     Add context fields to a channel.
 
-linklttng:lttng-disable-channel(1)::
+man:lttng-disable-channel(1)::
     Disable tracing channels.
 
-linklttng:lttng-enable-channel(1)::
+man:lttng-enable-channel(1)::
     Create or enable tracing channels.
 
 
 Event rules
 ~~~~~~~~~~~
-linklttng:lttng-disable-event(1)::
+man:lttng-disable-event(1)::
     Disable event rules.
 
-linklttng:lttng-enable-event(1)::
+man:lttng-enable-event(1)::
     Create or enable event rules.
 
 
 Status
 ~~~~~~
-linklttng:lttng-list(1)::
+man:lttng-list(1)::
     List tracing sessions, domains, channels, and events.
 
-linklttng:lttng-status(1)::
+man:lttng-status(1)::
     Get the status of the current tracing session.
 
 
 Control
 ~~~~~~~
-linklttng:lttng-snapshot(1)::
+man:lttng-snapshot(1)::
     Snapshot buffers of current tracing session.
 
-linklttng:lttng-start(1)::
+man:lttng-start(1)::
     Start tracing.
 
-linklttng:lttng-stop(1)::
+man:lttng-stop(1)::
     Stop tracing.
 
 
 Resource tracking
 ~~~~~~~~~~~~~~~~~
-linklttng:lttng-track(1)::
+man:lttng-track(1)::
     Track specific system resources.
 
-linklttng:lttng-untrack(1)::
+man:lttng-untrack(1)::
     Untrack specific system resources.
 
 
 Miscellaneous
 ~~~~~~~~~~~~~
-linklttng:lttng-calibrate(1)::
+man:lttng-calibrate(1)::
     Quantify LTTng overhead.
 
-linklttng:lttng-help(1)::
+man:lttng-help(1)::
     Display help information about a command.
 
-linklttng:lttng-version(1)::
+man:lttng-version(1)::
     Show version information.
 
-linklttng:lttng-view(1)::
+man:lttng-view(1)::
     Start trace viewer.
 
 
@@ -237,8 +237,8 @@ include::common-cmd-footer.txt[]
 
 SEE ALSO
 --------
-linklttng:lttng-sessiond(8),
-linklttng:lttng-relayd(8),
-linklttng:lttng-crash(1),
-linklttng:lttng-ust(3),
-linklttng:babeltrace(1)
+man:lttng-sessiond(8),
+man:lttng-relayd(8),
+man:lttng-crash(1),
+man:lttng-ust(3),
+man:babeltrace(1)

--- a/src/lib/lttng-ctl/filter/Makefile.am
+++ b/src/lib/lttng-ctl/filter/Makefile.am
@@ -7,9 +7,9 @@ noinst_HEADERS = filter-ast.h \
 		filter-symbols.h
 
 BUILT_SOURCES = filter-parser.h
-AM_YFLAGS = -t -d -v
 
-libfilter_la_SOURCES = filter-lexer.l filter-parser.y \
+libfilter_la_SOURCES = \
+	filter-parser.y filter-lexer.l \
 	filter-visitor-set-parent.c \
 	filter-visitor-xml.c \
 	filter-visitor-generate-ir.c \
@@ -22,7 +22,42 @@ libfilter_la_SOURCES = filter-lexer.l filter-parser.y \
 	memstream.h
 libfilter_la_CFLAGS = -include filter-symbols.h
 
+AM_YFLAGS = -t -d -v
+
+# start with empty files to clean
+CLEANFILES =
+
+if HAVE_BISON
+# we have bison: we can clean the generated parser files
+CLEANFILES += filter-parser.c filter-parser.h filter-parser.output
+else # HAVE_BISON
+# create target used to stop the build if we want to build the parser,
+# but we don't have the necessary tool to do so
+ERR_MSG = "Error: Cannot build target because bison is missing."
+ERR_MSG += "Make sure bison is installed and run the configure script again."
+
+filter-parser.c filter-parser.h: filter-parser.y
+	@echo $(ERR_MSG)
+	@false
+
+all-local: filter-parser.c filter-parser.h
+endif # HAVE_BISON
+
+if HAVE_FLEX
+# we have flex: we can clean the generated lexer files
+CLEANFILES += filter-lexer.c
+else # HAVE_FLEX
+# create target used to stop the build if we want to build the lexer,
+# but we don't have the necessary tool to do so
+ERR_MSG = "Error: Cannot build target because flex is missing."
+ERR_MSG += "Make sure flex is installed and run the configure script again."
+
+filter-lexer.c: filter-lexer.l
+	@echo $(ERR_MSG)
+	@false
+
+all-local: filter-lexer.c
+endif # HAVE_FLEX
+
 filter_grammar_test_SOURCES = filter-grammar-test.c
 filter_grammar_test_LDADD = libfilter.la
-
-CLEANFILES = filter-lexer.c filter-parser.c filter-parser.h filter-parser.output


### PR DESCRIPTION
This should cover most situations (rough estimate: 99.97%).

This solution assumes that pregenerated files distributed in the tarball always exist, and are always newer than their sources.

The real solution, which I think is overkill for the moment, would be to validate this assumption: at configure time, if a given pregenerated file does not exist, or if it's older than its source, then the tool to regenerate the file is absolutely required. This would allow the following situation:

  1. Get the tarball
  2. Modify the parser file source, or remove the pregenerated parser file
  3. `./configure` (you don't have Bison, for example): passes

After step 2, it is clear that the parser file should be regenerated from its modified source (or at all if it was removed). But step 3 passes, thus the parser file is either not up to date, or missing, in which case make fails.