### PR TITLE
ust-metadata.c: nest/indent enumeration entries

### DIFF
--- a/src/bin/lttng-sessiond/ust-metadata.c
+++ b/src/bin/lttng-sessiond/ust-metadata.c
@@ -262,6 +262,7 @@ int ust_metadata_enum_statedump(struct ust_registry_session *session,
 	if (ret) {
 	        goto end;
 	}
+	nesting++;
 	/* Dump all entries */
 	for (i = 0; i < nr_entries; i++) {
 		const struct ustctl_enum_entry *entry = &entries[i];
@@ -333,6 +334,7 @@ int ust_metadata_enum_statedump(struct ust_registry_session *session,
 			goto end;
 		}
 	}
+	nesting--;
 	sanitize_ctf_identifier(identifier, field_name);
 	ret = print_tabs(session, nesting);
 	if (ret) {


### PR DESCRIPTION
This looks nicer, IMO:

```
event {
	name = "barectf_tp:a_few_fields";
	id = 5;
	stream_id = 0;
	loglevel = 13;
	fields := struct {
		integer { size = 32; align = 8; signed = 1; encoding = none; base = 10; } _int32;
		integer { size = 16; align = 8; signed = 1; encoding = none; base = 10; } _int16;
		floating_point { exp_dig = 11; mant_dig = 53; align = 8; } _dbl;
		string _str;
		enum : integer { size = 32; align = 8; signed = 1; encoding = none; base = 10; } {
			"NEW" = 0,
			"TERMINATED" = 1,
			"READY" = 2,
			"RUNNING" = 3,
			"WAITING" = 4,
		} _state;
	};
};
```

Compare to:

```
event {
	name = "barectf_tp:a_few_fields";
	id = 5;
	stream_id = 0;
	loglevel = 13;
	fields := struct {
		integer { size = 32; align = 8; signed = 1; encoding = none; base = 10; } _int32;
		integer { size = 16; align = 8; signed = 1; encoding = none; base = 10; } _int16;
		floating_point { exp_dig = 11; mant_dig = 53; align = 8; } _dbl;
		string _str;
		enum : integer { size = 32; align = 8; signed = 1; encoding = none; base = 10; } {
		"NEW" = 0,
		"TERMINATED" = 1,
		"READY" = 2,
		"RUNNING" = 3,
		"WAITING" = 4,
		} _state;
	};
};
```