### PR TITLE
Embed --help messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ tests/regression/ust/python-logging/test_python_logging
 /doc/man/*.8
 /doc/man/*.xml
 /doc/man/*.html
+/doc/man/*.h
 /doc/man/asciidoc-attrs.conf
 !/doc/man/lttng-health-check.3
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,8 @@
 ACLOCAL_AMFLAGS = -I m4
 
-DIST_SUBDIRS = include src extras doc tests
+DIST_SUBDIRS = include doc src extras tests
 
-SUBDIRS = include src doc tests
+SUBDIRS = include doc src tests
 
 if BUILD_EXTRAS
 SUBDIRS += extras

--- a/configure.ac
+++ b/configure.ac
@@ -639,6 +639,29 @@ AM_CONDITIONAL([HAVE_ASCIIDOC_XMLTO], [test "x$have_asciidoc_xmlto" = "xyes"])
 
 AC_DEFINE_UNQUOTED([MANPATH], ["`eval eval echo $mandir`"], [Path to man pages.])
 
+# embedded --help message
+AC_ARG_ENABLE(
+	[embedded-help],
+	AS_HELP_STRING(
+		[--enable-embedded-help],
+		[Embed the --help messages in the executable files]
+	),
+	[embedded_help=$enableval],
+	[embedded_help=no]
+)
+AS_IF([test "x$embedded_help" = "xyes"], [
+	AS_IF([test "x$man_pages_opt" = "xno"], [
+		AC_MSG_ERROR([You need the --enable-man-pages option with the --enable-embedded-help option.])
+	])
+	AC_PATH_PROG([man_prog_path], [man], [no])
+	AS_IF([test "x$man_prog_path" = "xno"], [
+		AC_MSG_ERROR([You need man with the --enable-embedded-help option.])
+	])
+	AC_DEFINE_UNQUOTED([LTTNG_EMBED_HELP], 1, [Embed --help messages.])
+	AC_SUBST([MANPROG], [$man_prog_path])
+])
+AM_CONDITIONAL([EMBED_HELP], [test "x$embedded_help" != "xno"])
+
 # Python agent test
 UST_PYTHON_AGENT="lttngust"
 
@@ -1158,6 +1181,9 @@ AS_IF([test "x$man_pages_opt" != "xno"], [
 ])
 
 m4_popdef([build_man_pages_msg])
+
+test "x$embedded_help" = xyes && value=1 || value=0
+PPRINT_PROP_BOOL([Embed --help messages], $value, $PPRINT_COLOR_SUBTITLE)
 
 PPRINT_SET_INDENT(1)
 

--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -73,6 +73,34 @@ MAN3_NO_ASCIIDOC = $(addsuffix .3,$(MAN3_NO_ASCIIDOC_NAMES))
 MAN8_NO_ASCIIDOC = $(addsuffix .8,$(MAN8_NO_ASCIIDOC_NAMES))
 MAN = $(MAN1) $(MAN3) $(MAN8)
 
+# initially empty
+CLEANFILES =
+
+if EMBED_HELP
+MAN1_H = $(addsuffix .1.h,$(MAN1_NAMES))
+MAN3_H = $(addsuffix .3.h,$(MAN3_NAMES))
+MAN8_H = $(addsuffix .8.h,$(MAN8_NAMES))
+MAN_H = $(MAN1_H) $(MAN3_H) $(MAN8_H)
+MAN_H_RECIPE = \
+	MANWIDTH=80 @MANPROG@ --encoding=UTF-8 --no-hyphenation --no-justification --local-file $< > $@ ; \
+	$(SED) -i 's/\\/\\\\/g' $@ ; \
+	$(SED) -i 's/"/\\"/g' $@ ; \
+	$(SED) -i 's/^\(.*\)$$/"\1\\n"/' $@
+
+%.1.h: %.1
+	$(MAN_H_RECIPE)
+
+%.3.h: %.3
+	$(MAN_H_RECIPE)
+
+%.8.h: %.8
+	$(MAN_H_RECIPE)
+
+all-local: $(MAN_H)
+
+CLEANFILES += $(MAN_H)
+endif # EMBED_HELP
+
 if MAN_PAGES_OPT
 # at this point, we know the user asked to build the man pages
 if HAVE_ASCIIDOC_XMLTO
@@ -106,7 +134,7 @@ COMMON_DEPS += $(ASCIIDOC_ATTRS_CONF)
 	$(XTO) $<
 
 # only clean the generated files if we have the tools to generate them again
-CLEANFILES = $(MAN_XML) $(MAN)
+CLEANFILES += $(MAN_XML) $(MAN)
 else # HAVE_ASCIIDOC_XMLTO
 # create man page targets used to stop the build if we want to
 # build the man pages, but we don't have the necessary tools to do so
@@ -148,3 +176,6 @@ endif # !MAN_PAGES_OPT
 # always distribute the source files
 EXTRA_DIST = $(MAN_TXT) $(COMMON_TXT) $(XSL_SRC_FILES) \
 	$(ASCIIDOC_CONF) $(ASCIIDOC_ATTRS_CONF).in
+
+# keep generated man pages that can be considered intermediate files
+.PRECIOUS: %.1 %.3 %.8

--- a/src/bin/lttng-crash/Makefile.am
+++ b/src/bin/lttng-crash/Makefile.am
@@ -1,6 +1,10 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src \
 			  -DINSTALL_BIN_PATH=\""$(bindir)"\"
 
+if EMBED_HELP
+AM_CPPFLAGS += -I$(top_builddir)/doc/man
+endif
+
 bin_PROGRAMS = lttng-crash
 
 lttng_crash_SOURCES = lttng-crash.c

--- a/src/bin/lttng-crash/lttng-crash.c
+++ b/src/bin/lttng-crash/lttng-crash.c
@@ -61,6 +61,14 @@
 		0xF1 ^ 0xFF, 0x77 ^ 0xFF, 0xBF ^ 0xFF, 0x17 ^ 0xFF,	\
 	}
 
+static const char *help_msg =
+#ifdef LTTNG_EMBED_HELP
+#include <lttng-crash.1.h>
+#else
+NULL
+#endif
+;
+
 /*
  * Non-static to ensure the compiler does not optimize away the xor.
  */
@@ -207,10 +215,10 @@ static struct option long_options[] = {
 
 static void usage(void)
 {
-	int ret = utils_show_man_page(1, "lttng-crash");
+	int ret = utils_show_help(1, "lttng-crash", help_msg);
 
 	if (ret) {
-		ERR("Cannot view man page lttng-crash(1)");
+		ERR("Cannot show --help for `lttng-crash`");
 		perror("exec");
 		exit(EXIT_FAILURE);
 	}

--- a/src/bin/lttng-relayd/Makefile.am
+++ b/src/bin/lttng-relayd/Makefile.am
@@ -2,6 +2,10 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src \
 			  -DINSTALL_BIN_PATH=\""$(lttnglibexecdir)"\" \
 			  -DINSTALL_LIB_PATH=\""$(libdir)"\"
 
+if EMBED_HELP
+AM_CPPFLAGS += -I$(top_builddir)/doc/man
+endif
+
 AM_CFLAGS = -fno-strict-aliasing
 
 bin_PROGRAMS = lttng-relayd

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -71,6 +71,14 @@
 #include "connection.h"
 #include "tracefile-array.h"
 
+static const char *help_msg =
+#ifdef LTTNG_EMBED_HELP
+#include <lttng-relayd.8.h>
+#else
+NULL
+#endif
+;
+
 /* command line options */
 char *opt_output_path;
 static int opt_daemon, opt_background;
@@ -250,9 +258,9 @@ static int set_option(int opt, const char *arg, const char *optname)
 		}
 		break;
 	case 'h':
-		ret = utils_show_man_page(8, "lttng-relayd");
+		ret = utils_show_help(8, "lttng-relayd", help_msg);
 		if (ret) {
-			ERR("Cannot view man page lttng-relayd(8)");
+			ERR("Cannot show --help for `lttng-relayd`");
 			perror("exec");
 		}
 		exit(EXIT_FAILURE);

--- a/src/bin/lttng-sessiond/Makefile.am
+++ b/src/bin/lttng-sessiond/Makefile.am
@@ -2,6 +2,10 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src \
 			  -DINSTALL_BIN_PATH=\""$(lttnglibexecdir)"\" \
 			  -DINSTALL_LIB_PATH=\""$(libdir)"\"
 
+if EMBED_HELP
+AM_CPPFLAGS += -I$(top_builddir)/doc/man
+endif
+
 AM_CFLAGS = -fno-strict-aliasing
 
 bin_PROGRAMS = lttng-sessiond

--- a/src/bin/lttng-sessiond/main.c
+++ b/src/bin/lttng-sessiond/main.c
@@ -77,6 +77,14 @@
 
 #define CONSUMERD_FILE	"lttng-consumerd"
 
+static const char *help_msg =
+#ifdef LTTNG_EMBED_HELP
+#include <lttng-sessiond.8.h>
+#else
+NULL
+#endif
+;
+
 const char *progname;
 static const char *tracing_group_name = DEFAULT_TRACING_GROUP;
 static int tracing_group_name_override;
@@ -4677,9 +4685,9 @@ static int set_option(int opt, const char *arg, const char *optname)
 			tracing_group_name_override = 1;
 		}
 	} else if (string_match(optname, "help") || opt == 'h') {
-		ret = utils_show_man_page(8, "lttng-sessiond");
+		ret = utils_show_help(8, "lttng-sessiond", help_msg);
 		if (ret) {
-			ERR("Cannot view man page lttng-sessiond(8)");
+			ERR("Cannot show --help for `lttng-sessiond`");
 			perror("exec");
 		}
 		exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);

--- a/src/bin/lttng/Makefile.am
+++ b/src/bin/lttng/Makefile.am
@@ -1,6 +1,10 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src \
 			  -DINSTALL_BIN_PATH=\""$(bindir)"\"
 
+if EMBED_HELP
+AM_CPPFLAGS += -I$(top_builddir)/doc/man
+endif
+
 AUTOMAKE_OPTIONS = subdir-objects
 
 bin_PROGRAMS = lttng

--- a/src/bin/lttng/command.h
+++ b/src/bin/lttng/command.h
@@ -28,13 +28,20 @@
 #define DECL_COMMAND(_name) \
 	extern int cmd_##_name(int, const char **)
 
+#ifdef LTTNG_EMBED_HELP
+# define HELP_MSG_NAME		help_msg
+# define SHOW_HELP_ERROR_LINE	ERR("Cannot show --help for `lttng-%s`", argv[0]);
+#else
+# define HELP_MSG_NAME		NULL
+# define SHOW_HELP_ERROR_LINE	;
+#endif
+
 #define SHOW_HELP() 							\
 	do {								\
-		ret = show_cmd_man_page(argv[0]);			\
+		ret = show_cmd_help(argv[0], HELP_MSG_NAME);		\
 									\
 		if (ret) {						\
-			ERR("Cannot view man page lttng-%s(1)", argv[0]); \
-			perror("exec");					\
+			SHOW_HELP_ERROR_LINE 				\
 			ret = CMD_ERROR;				\
 		}							\
 	} while (0)

--- a/src/bin/lttng/commands/add_context.c
+++ b/src/bin/lttng/commands/add_context.c
@@ -41,6 +41,12 @@ static int opt_jul;
 static int opt_log4j;
 static char *opt_type;
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-add-context.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_TYPE,

--- a/src/bin/lttng/commands/create.c
+++ b/src/bin/lttng/commands/create.c
@@ -51,6 +51,12 @@ static int opt_no_output;
 static int opt_snapshot;
 static unsigned int opt_live_timer;
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-create.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_LIST_OPTIONS,

--- a/src/bin/lttng/commands/destroy.c
+++ b/src/bin/lttng/commands/destroy.c
@@ -35,6 +35,12 @@ static char *opt_session_name;
 static int opt_destroy_all;
 static int opt_no_wait;
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-destroy.1.h>
+;
+#endif
+
 /* Mi writer */
 static struct mi_writer *writer;
 

--- a/src/bin/lttng/commands/disable_channels.c
+++ b/src/bin/lttng/commands/disable_channels.c
@@ -34,6 +34,12 @@ static int opt_kernel;
 static char *opt_session_name;
 static int opt_userspace;
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-disable-channel.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_USERSPACE,

--- a/src/bin/lttng/commands/disable_events.c
+++ b/src/bin/lttng/commands/disable_events.c
@@ -40,6 +40,12 @@ static int opt_log4j;
 static int opt_python;
 static int opt_event_type;
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-disable-event.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_TYPE_SYSCALL,

--- a/src/bin/lttng/commands/enable_channels.c
+++ b/src/bin/lttng/commands/enable_channels.c
@@ -47,6 +47,12 @@ static int opt_buffer_global;
 
 static struct mi_writer *writer;
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-enable-channel.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_DISCARD,

--- a/src/bin/lttng/commands/enable_events.c
+++ b/src/bin/lttng/commands/enable_events.c
@@ -55,6 +55,12 @@ static char *opt_channel_name;
 static char *opt_filter;
 static char *opt_exclude;
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-enable-event.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_TRACEPOINT,

--- a/src/bin/lttng/commands/help.c
+++ b/src/bin/lttng/commands/help.c
@@ -25,6 +25,22 @@
 #include "../command.h"
 #include <common/utils.h>
 
+static const char *help_msg =
+#ifdef LTTNG_EMBED_HELP
+#include <lttng-help.1.h>
+#else
+NULL
+#endif
+;
+
+static const char *lttng_help_msg =
+#ifdef LTTNG_EMBED_HELP
+#include <lttng.1.h>
+#else
+NULL
+#endif
+;
+
 enum {
 	OPT_HELP = 1,
 	OPT_LIST_OPTIONS,
@@ -71,14 +87,14 @@ int cmd_help(int argc, const char **argv, const struct cmd_struct commands[])
 
 	if (cmd_name == NULL) {
 		/* Fall back to lttng(1) */
-		ret = utils_show_man_page(1, "lttng");
-
+		ret = utils_show_help(1, "lttng", lttng_help_msg);
 		if (ret) {
-			ERR("Cannot view man page lttng(1)");
+			ERR("Cannot show --help for `lttng`");
 			perror("exec");
 			ret = CMD_ERROR;
-			goto end;
 		}
+
+		goto end;
 	}
 
 	/* Help about help? */

--- a/src/bin/lttng/commands/help.c
+++ b/src/bin/lttng/commands/help.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 #include "../command.h"
 #include <common/utils.h>
@@ -46,6 +47,7 @@ int cmd_help(int argc, const char **argv, const struct cmd_struct commands[])
 	static poptContext pc;
 	const struct cmd_struct *cmd;
 	int found = 0;
+	const char *cmd_argv[2];
 
 	pc = poptGetContext(NULL, argc, argv, long_options, 0);
 	poptReadDefaultConfig(pc, 0);
@@ -79,6 +81,12 @@ int cmd_help(int argc, const char **argv, const struct cmd_struct commands[])
 		}
 	}
 
+	/* Help about help? */
+	if (strcmp(cmd_name, "help") == 0) {
+		SHOW_HELP();
+		goto end;
+	}
+
 	/* Make sure command name exists */
 	cmd = &commands[0];
 
@@ -97,14 +105,11 @@ int cmd_help(int argc, const char **argv, const struct cmd_struct commands[])
 		goto end;
 	}
 
-	/* Show command's man page */
-	ret = show_cmd_man_page(cmd_name);
-
-	if (ret) {
-		ERR("Cannot view man page lttng-%s(1)", cmd_name);
-		perror("exec");
-		ret = CMD_ERROR;
-	}
+	/* Show command's help */
+	cmd_argv[0] = cmd->name;
+	cmd_argv[1] = "--help";
+	assert(cmd->func);
+	ret = cmd->func(2, cmd_argv);
 
 end:
 	poptFreeContext(pc);

--- a/src/bin/lttng/commands/list.c
+++ b/src/bin/lttng/commands/list.c
@@ -42,6 +42,12 @@ const char *indent4 = "    ";
 const char *indent6 = "      ";
 const char *indent8 = "        ";
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-list.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_USERSPACE,

--- a/src/bin/lttng/commands/load.c
+++ b/src/bin/lttng/commands/load.c
@@ -37,6 +37,12 @@ static int opt_load_all;
 
 static const char *session_name;
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-load.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_ALL,

--- a/src/bin/lttng/commands/metadata.c
+++ b/src/bin/lttng/commands/metadata.c
@@ -33,6 +33,12 @@ static char *session_name = NULL;
 
 static int metadata_regenerate(int argc, const char **argv);
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-metadata.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_LIST_OPTIONS,

--- a/src/bin/lttng/commands/regenerate.c
+++ b/src/bin/lttng/commands/regenerate.c
@@ -34,6 +34,12 @@ static char *session_name = NULL;
 static int regenerate_metadata(int argc, const char **argv);
 static int regenerate_statedump(int argc, const char **argv);
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-regenerate.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_LIST_OPTIONS,

--- a/src/bin/lttng/commands/save.c
+++ b/src/bin/lttng/commands/save.c
@@ -33,6 +33,12 @@ static bool opt_force;
 static bool opt_save_all;
 static struct mi_writer *writer;
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-save.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_ALL,

--- a/src/bin/lttng/commands/set_session.c
+++ b/src/bin/lttng/commands/set_session.c
@@ -31,6 +31,12 @@
 
 static char *opt_session_name;
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-set-session.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_LIST_OPTIONS,

--- a/src/bin/lttng/commands/snapshot.c
+++ b/src/bin/lttng/commands/snapshot.c
@@ -48,6 +48,12 @@ static int cmd_record(int argc, const char **argv);
 
 static const char *indent4 = "    ";
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-snapshot.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_LIST_OPTIONS,

--- a/src/bin/lttng/commands/start.c
+++ b/src/bin/lttng/commands/start.c
@@ -33,6 +33,12 @@
 static char *opt_session_name;
 static struct mi_writer *writer;
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-start.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_LIST_OPTIONS,

--- a/src/bin/lttng/commands/status.c
+++ b/src/bin/lttng/commands/status.c
@@ -28,6 +28,12 @@
 #include "../utils.h"
 #include <config.h>
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-status.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_LIST_OPTIONS,

--- a/src/bin/lttng/commands/stop.c
+++ b/src/bin/lttng/commands/stop.c
@@ -34,6 +34,12 @@ static char *opt_session_name;
 static int opt_no_wait;
 static struct mi_writer *writer;
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-stop.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_LIST_OPTIONS,

--- a/src/bin/lttng/commands/track-untrack.c
+++ b/src/bin/lttng/commands/track-untrack.c
@@ -320,7 +320,7 @@ const char *get_mi_element_command(enum cmd_type cmd_type)
  */
 static
 int cmd_track_untrack(enum cmd_type cmd_type, const char *cmd_str,
-		int argc, const char **argv)
+		int argc, const char **argv, const char *help_msg)
 {
 	int opt, ret = 0;
 	enum cmd_error_code command_ret = CMD_SUCCESS;
@@ -454,10 +454,26 @@ end:
 
 int cmd_track(int argc, const char **argv)
 {
-	return cmd_track_untrack(CMD_TRACK, "track", argc, argv);
+	static const char *help_msg =
+#ifdef LTTNG_EMBED_HELP
+#include <lttng-track.1.h>
+#else
+	NULL
+#endif
+	;
+
+	return cmd_track_untrack(CMD_TRACK, "track", argc, argv, help_msg);
 }
 
 int cmd_untrack(int argc, const char **argv)
 {
-	return cmd_track_untrack(CMD_UNTRACK, "untrack", argc, argv);
+	static const char *help_msg =
+#ifdef LTTNG_EMBED_HELP
+#include <lttng-untrack.1.h>
+#else
+	NULL
+#endif
+	;
+
+	return cmd_track_untrack(CMD_UNTRACK, "untrack", argc, argv, help_msg);
 }

--- a/src/bin/lttng/commands/version.c
+++ b/src/bin/lttng/commands/version.c
@@ -28,6 +28,12 @@
 
 #include "../command.h"
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-version.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_LIST_OPTIONS,

--- a/src/bin/lttng/commands/view.c
+++ b/src/bin/lttng/commands/view.c
@@ -32,6 +32,12 @@ static char *opt_trace_path;
 static const char *babeltrace_bin = CONFIG_BABELTRACE_BIN;
 //static const char *lttv_gui_bin = CONFIG_LTTV_GUI_BIN;
 
+#ifdef LTTNG_EMBED_HELP
+static const char help_msg[] =
+#include <lttng-view.1.h>
+;
+#endif
+
 enum {
 	OPT_HELP = 1,
 	OPT_LIST_OPTIONS,

--- a/src/bin/lttng/lttng.c
+++ b/src/bin/lttng/lttng.c
@@ -33,6 +33,14 @@
 
 #include "command.h"
 
+static const char *help_msg =
+#ifdef LTTNG_EMBED_HELP
+#include <lttng.1.h>
+#else
+NULL
+#endif
+;
+
 /* Variables */
 static char *progname;
 int opt_no_sessiond;
@@ -315,10 +323,9 @@ static int parse_args(int argc, char **argv)
 			ret = 0;
 			goto end;
 		case 'h':
-			ret = utils_show_man_page(1, "lttng");
-
+			ret = utils_show_help(1, "lttng", help_msg);
 			if (ret) {
-				ERR("Cannot view man page lttng(1)");
+				ERR("Cannot show --help for `lttng`");
 				perror("exec");
 			}
 			goto end;

--- a/src/bin/lttng/lttng.c
+++ b/src/bin/lttng/lttng.c
@@ -76,6 +76,7 @@ static struct cmd_struct commands[] =  {
 	{ "list", cmd_list},
 	{ "load", cmd_load},
 	{ "metadata", cmd_metadata},
+	{ "regenerate", cmd_regenerate},
 	{ "save", cmd_save},
 	{ "set-session", cmd_set_session},
 	{ "snapshot", cmd_snapshot},
@@ -84,10 +85,8 @@ static struct cmd_struct commands[] =  {
 	{ "stop", cmd_stop},
 	{ "track", cmd_track},
 	{ "untrack", cmd_untrack},
-	{ "help", NULL},
 	{ "version", cmd_version},
 	{ "view", cmd_view},
-	{ "regenerate", cmd_regenerate},
 	{ NULL, NULL}	/* Array closure */
 };
 

--- a/src/bin/lttng/utils.c
+++ b/src/bin/lttng/utils.c
@@ -482,13 +482,18 @@ end:
 	return;
 }
 
-int show_cmd_man_page(const char *cmd_name)
+int show_cmd_help(const char *cmd_name, const char *help_msg)
 {
 	int ret;
 	char page_name[32];
 
 	ret = sprintf(page_name, "lttng-%s", cmd_name);
 	assert(ret > 0 && ret < 32);
+	ret = utils_show_help(1, page_name, help_msg);
+	if (ret && !help_msg) {
+		ERR("Cannot view man page `lttng-%s(1)`", cmd_name);
+		perror("exec");
+	}
 
-	return utils_show_man_page(1, page_name);
+	return ret;
 }

--- a/src/bin/lttng/utils.h
+++ b/src/bin/lttng/utils.h
@@ -60,6 +60,6 @@ int print_missing_or_multiple_domains(unsigned int sum);
 int spawn_relayd(const char *pathname, int port);
 int check_relayd(void);
 void print_session_stats(const char *session_name);
-int show_cmd_man_page(const char *cmd_name);
+int show_cmd_help(const char *cmd_name, const char *help_msg);
 
 #endif /* _LTTNG_UTILS_H */

--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -1362,11 +1362,17 @@ static const char *get_man_bin_path(void)
 }
 
 LTTNG_HIDDEN
-int utils_show_man_page(int section, const char *page_name)
+int utils_show_help(int section, const char *page_name,
+		const char *help_msg)
 {
 	char section_string[8];
 	const char *man_bin_path = get_man_bin_path();
-	int ret;
+	int ret = 0;
+
+	if (help_msg) {
+		printf("%s", help_msg);
+		goto end;
+	}
 
 	/* Section integer -> section string */
 	ret = sprintf(section_string, "%d", section);
@@ -1381,5 +1387,7 @@ int utils_show_man_page(int section, const char *page_name)
 	 */
 	ret = execlp(man_bin_path, "man", "-M", MANPATH,
 		section_string, page_name, NULL);
+
+end:
 	return ret;
 }

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -59,6 +59,6 @@ char *utils_generate_optstring(const struct option *long_options,
 int utils_create_lock_file(const char *filepath);
 int utils_recursive_rmdir(const char *path);
 int utils_truncate_stream_file(int fd, off_t length);
-int utils_show_man_page(int section, const char *page_name);
+int utils_show_help(int section, const char *page_name, const char *help_msg);
 
 #endif /* _COMMON_UTILS_H */


### PR DESCRIPTION
See the detailed commit message of a52c482.

Tested with the following configurations, from a tarball:

* In-tree build:
  * Without `--enable-embedded-help`: does not generate the C string files
  * With `--enable-embedded-help`
    * With existing `asciidoc` program: builds the man pages, then generates the C string files
    * Without existing `asciidoc` program: generates the C string files from the pregenerated man pages
* Out-of-tree build:
  * Without `--enable-embedded-help`: does not generate the C string files
  * With `--enable-embedded-help`
    * With existing `asciidoc` program: builds the man pages, then generates the C string files from the man pages found in the _build_ directory
    * Without existing `asciidoc` program: generates the C string files from the pregenerated man pages found in the _source_ directory

`--disable-man-pages` and `--enable-embedded-help` is not a valid configuration.