### PR TITLE
doc/man: add typical `$` and `#` prompts to command lines

### DIFF
--- a/doc/man/lttng-enable-channel.1.txt
+++ b/doc/man/lttng-enable-channel.1.txt
@@ -201,10 +201,10 @@ in conjunction with the option:--tracefile-size option.
 For example, consider this command:
 
 [role="term"]
------------------------------------------------------
-lttng enable-channel --kernel --tracefile-size=4096 \
+----
+$ lttng enable-channel --kernel --tracefile-size=4096 \
                      --tracefile-count=32 my-channel
------------------------------------------------------
+----
 
 Here, for each stream, the maximum size of each trace file is
 4 kiB and there can be a maximum of 32 different files. When there is

--- a/doc/man/lttng-enable-event.1.txt
+++ b/doc/man/lttng-enable-event.1.txt
@@ -107,10 +107,10 @@ a _don't care_.
 For example, consider the following commands:
 
 [role="term"]
-----------------------------------------------------------------
-lttng enable-event --userspace hello:world
-lttng enable-event --userspace hello:world --loglevel=TRACE_INFO
-----------------------------------------------------------------
+----
+$ lttng enable-event --userspace hello:world
+$ lttng enable-event --userspace hello:world --loglevel=TRACE_INFO
+----
 
 Here, two event rules are created. The first one has a single condition:
 the tracepoint name must match `hello:world`. The second one has two

--- a/doc/man/lttng-help.1.txt
+++ b/doc/man/lttng-help.1.txt
@@ -21,9 +21,9 @@ command.
 This command is the equivalent of:
 
 [role="term"]
---------------------
-lttng COMMAND --help
---------------------
+----
+$ lttng COMMAND --help
+----
 
 where `COMMAND` is the name of the command about which to get help. If
 'COMMAND' is omitted, `lttng help` shows general help about the

--- a/doc/man/lttng-snapshot.1.txt
+++ b/doc/man/lttng-snapshot.1.txt
@@ -86,9 +86,9 @@ Taking a snapshot
 Taking a snapshot of the current tracing session is as easy as:
 
 [role="term"]
----------------------
-lttng snapshot record
----------------------
+----
+$ lttng snapshot record
+----
 
 This writes the snapshot files to the configured output. It is possible
 to use a custom, unregistered output at record time using the same

--- a/doc/man/lttng-status.1.txt
+++ b/doc/man/lttng-status.1.txt
@@ -21,9 +21,9 @@ tracing session.
 This command is the exact equivalent of:
 
 [role="term"]
----------------------
-lttng list CURSESSION
----------------------
+----
+$ lttng list CURSESSION
+----
 
 where `CURSESSION` is the name of the current tracing session.
 Use man:lttng-set-session(1) to set the current tracing session.

--- a/doc/man/lttng-track.1.txt
+++ b/doc/man/lttng-track.1.txt
@@ -36,11 +36,11 @@ With the PID tracker, it is possible, for example, to record all system
 calls called by a given process:
 
 [role="term"]
--------------------------------------------
-lttng enable-event --kernel --all --syscall
-lttng track --kernel --pid=2345
-lttng start
--------------------------------------------
+----
+# lttng enable-event --kernel --all --syscall
+# lttng track --kernel --pid=2345
+# lttng start
+----
 
 If all the PIDs are tracked (i.e. `lttng track --pid --all`, which is
 the default state of all domains when creating a tracing session), then
@@ -62,9 +62,9 @@ Initial whitelist:
 Command:
 
 [role="term"]
------------------------------------
-lttng track --userspace --pid=3,6,7
------------------------------------
+----
+$ lttng track --userspace --pid=3,6,7
+----
 
 Whitelist:
 
@@ -75,9 +75,9 @@ Whitelist:
 Command:
 
 [role="term"]
----------------------------------
-lttng untrack --userspace --pid=7
----------------------------------
+----
+$ lttng untrack --userspace --pid=7
+----
 
 Whitelist:
 
@@ -88,9 +88,9 @@ Whitelist:
 Command:
 
 [role="term"]
----------------------------------
-lttng track --userspace --pid=1,5
----------------------------------
+----
+$ lttng track --userspace --pid=1,5
+----
 
 Whitelist:
 

--- a/doc/man/lttng-untrack.1.txt
+++ b/doc/man/lttng-untrack.1.txt
@@ -41,9 +41,9 @@ Assume the maximum system PID is 7 for this example.
 Command:
 
 [role="term"]
-------------
-lttng create
-------------
+----
+$ lttng create
+----
 
 Initial whitelist:
 
@@ -54,9 +54,9 @@ Initial whitelist:
 Command:
 
 [role="term"]
--------------------------------------
-lttng untrack --userspace --pid --all
--------------------------------------
+----
+$ lttng untrack --userspace --pid --all
+----
 
 Whitelist:
 
@@ -67,12 +67,12 @@ Whitelist:
 Commands:
 
 [role="term"]
-----------------------------------
-lttng enable-event --userspace ...
-lttng start
-# ...
-lttng track --userspace --pid=3,5
-----------------------------------
+----
+$ lttng enable-event --userspace ...
+$ lttng start
+$ # ...
+$ lttng track --userspace --pid=3,5
+----
 
 Whitelist:
 
@@ -83,9 +83,9 @@ Whitelist:
 Command:
 
 [role="term"]
--------------------------------
-lttng track --userspace --pid=2
--------------------------------
+----
+$ lttng track --userspace --pid=2
+----
 
 Whitelist:
 


### PR DESCRIPTION
It is more instinctive for the typical reader to immediately recognize
command lines when they start with the classic prompts.

On the online version of the man pages, those prompts are treated
specially to make them non-selectable. This makes it possible to copy
multiple command lines at once (without copying the prompts) and to
paste them to your shell.