### PR TITLE
Fix: Make version.h generation work with dash

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -21,7 +21,7 @@ version.h:
 		##
 		## Check whether we are in a git repo.
 		##
-		git_describe="$$($(GIT_DESCRIBE_CMD) 2>/dev/null)"; \
+		git_describe="`$(GIT_DESCRIBE_CMD) 2>/dev/null`"; \
 		if [ $$? -eq 0 ]; then \
 			git_version="$${git_describe}"; \
 		else \


### PR DESCRIPTION
version.h generation failed when using dash as shell:
Generating version.h... /bin/sh: 24: Syntax error: Missing '))'

dash does not handle the following construct:
git_describe="$((cd /path/to/lttng-tools/.; git describe) 2>/dev/null)"

Use backquotes instead.

The fix has been tested with dash and bash.