### PR TITLE
Fix: remove unused event types in MI XML schema

### DIFF
--- a/src/common/mi-lttng-3.0.xsd
+++ b/src/common/mi-lttng-3.0.xsd
@@ -73,8 +73,6 @@ THE SOFTWARE.
 			<xs:enumeration value="FUNCTION_ENTRY" />
 			<xs:enumeration value="NOOP" />
 			<xs:enumeration value="SYSCALL" />
-			<xs:enumeration value="KPROBE" />
-			<xs:enumeration value="KRETPROBE" />
 		</xs:restriction>
 	</xs:simpleType>
 


### PR DESCRIPTION
KPROBE and KRETPROBE event types are never produced by the MI output,
PROBE and FUNCTION are rightfully used. Using KPROBE and KRETPROBE would
be exposing the inner workings of the kernel tracer that should be
abstracted to the user.

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>