### PR TITLE
Support probes with the same name but different event payload

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1090,6 +1090,7 @@ AC_CONFIG_FILES([
 	tests/regression/ust/buffers-pid/Makefile
 	tests/regression/ust/periodical-metadata-flush/Makefile
 	tests/regression/ust/multi-session/Makefile
+	tests/regression/ust/multi-lib/Makefile
 	tests/regression/ust/overlap/Makefile
 	tests/regression/ust/overlap/demo/Makefile
 	tests/regression/ust/linking/Makefile

--- a/src/bin/lttng-sessiond/Makefile.am
+++ b/src/bin/lttng-sessiond/Makefile.am
@@ -40,7 +40,8 @@ lttng_sessiond_SOURCES = utils.c utils.h \
 if HAVE_LIBLTTNG_UST_CTL
 lttng_sessiond_SOURCES += trace-ust.c ust-registry.c ust-app.c \
 			ust-consumer.c ust-consumer.h ust-thread.c \
-			ust-metadata.c ust-clock.h agent-thread.c agent-thread.h
+			ust-metadata.c ust-clock.h agent-thread.c agent-thread.h \
+			ust-field-utils.h ust-field-utils.c
 endif
 
 # Add main.c at the end for compile order

--- a/src/bin/lttng-sessiond/ust-field-utils.c
+++ b/src/bin/lttng-sessiond/ust-field-utils.c
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2018 - Francis Deslauriers <francis.deslauriers@efficios.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdbool.h>
+#include <string.h>
+
+#include "ust-field-utils.h"
+
+/*
+ * The ustctl_field is made of a combination of C basic types
+ * ustctl_basic_type and _ustctl_basic_type.
+ *
+ * ustctl_basic_type contains an enumeration describing the abstract type.
+ * _ustctl_basic_type does _NOT_ contain an enumeration describing the
+ * abstract type.
+ *
+ * A layer is needed to use the same code for both structures.
+ * When dealing with _ustctl_basic_type, we need to use the abstract type of
+ * the ustctl_type struct.
+ */
+
+/*
+ * Compare two ustctl_integer_type fields.
+ * Returns 1 if both are identical.
+ */
+static bool match_ustctl_field_integer(struct ustctl_integer_type *first,
+			struct ustctl_integer_type *second)
+{
+	if (first->size != second->size) {
+		goto no_match;
+	}
+	if (first->alignment != second->alignment) {
+		goto no_match;
+	}
+	if (first->signedness != second->signedness) {
+		goto no_match;
+	}
+	if (first->encoding != second->encoding) {
+		goto no_match;
+	}
+	if (first->base != second->base) {
+		goto no_match;
+	}
+	if (first->reverse_byte_order != second->reverse_byte_order) {
+		goto no_match;
+	}
+
+	return true;
+
+no_match:
+	return false;
+}
+
+/*
+ * Compare two _ustctl_basic_type fields known to be of type integer.
+ * Returns 1 if both are identical.
+ */
+static bool match_ustctl_field_integer_from_raw_basic_type(
+			union _ustctl_basic_type *first, union _ustctl_basic_type *second)
+{
+	return match_ustctl_field_integer(&first->integer, &second->integer);
+}
+
+/*
+ * Compare two _ustctl_basic_type fields known to be of type enum.
+ * Returns 1 if both are identical.
+ */
+static bool match_ustctl_field_enum_from_raw_basic_type(
+			union _ustctl_basic_type *first, union _ustctl_basic_type *second)
+{
+	/*
+	 * Compare enumeration ID. Enumeration ID is provided to the application by
+	 * the session daemon before event registration.
+	 */
+	if (first->enumeration.id != second->enumeration.id) {
+		goto no_match;
+	}
+
+	/*
+	 * Sanity check of the name and container type. Those were already checked
+	 * during enum registration.
+	 */
+	if (strncmp(first->enumeration.name, second->enumeration.name,
+				LTTNG_UST_SYM_NAME_LEN)) {
+		goto no_match;
+	}
+	if (!match_ustctl_field_integer(&first->enumeration.container_type,
+				&second->enumeration.container_type)) {
+		goto no_match;
+	}
+
+	return true;
+
+no_match:
+	return false;
+}
+
+/*
+ * Compare two _ustctl_basic_type fields known to be of type string.
+ * Returns 1 if both are identical.
+ */
+static bool match_ustctl_field_string_from_raw_basic_type(
+			union _ustctl_basic_type *first, union _ustctl_basic_type *second)
+{
+	return first->string.encoding == second->string.encoding;
+}
+
+/*
+ * Compare two _ustctl_basic_type fields known to be of type float.
+ * Returns 1 if both are identical.
+ */
+static bool match_ustctl_field_float_from_raw_basic_type(
+			union _ustctl_basic_type *first, union _ustctl_basic_type *second)
+{
+	if (first->_float.exp_dig != second->_float.exp_dig) {
+		goto no_match;
+	}
+
+	if (first->_float.mant_dig != second->_float.mant_dig) {
+		goto no_match;
+	}
+
+	if (first->_float.reverse_byte_order !=
+			second->_float.reverse_byte_order) {
+		goto no_match;
+	}
+
+	if (first->_float.alignment != second->_float.alignment) {
+		goto no_match;
+	}
+
+	return true;
+
+no_match:
+	return false;
+}
+
+/*
+ * Compare two _ustctl_basic_type fields given their respective abstract types.
+ * Returns 1 if both are identical.
+ */
+static bool match_ustctl_field_raw_basic_type(
+			enum ustctl_abstract_types first_atype,
+			union _ustctl_basic_type *first,
+			enum ustctl_abstract_types second_atype,
+			union _ustctl_basic_type *second)
+{
+	if (first_atype != second_atype) {
+		goto no_match;
+	}
+
+	switch (first_atype) {
+	case ustctl_atype_integer:
+		if (!match_ustctl_field_integer_from_raw_basic_type(first, second)) {
+			goto no_match;
+		}
+		break;
+	case ustctl_atype_enum:
+		if (!match_ustctl_field_enum_from_raw_basic_type(first, second)) {
+			goto no_match;
+		}
+		break;
+	case ustctl_atype_string:
+		if (!match_ustctl_field_string_from_raw_basic_type(first, second)) {
+			goto no_match;
+		}
+		break;
+	case ustctl_atype_float:
+		if (!match_ustctl_field_float_from_raw_basic_type(first, second)) {
+			goto no_match;
+		}
+		break;
+	default:
+		goto no_match;
+	}
+
+	return true;
+
+no_match:
+	return false;
+}
+
+/*
+ * Compatibility layer between the ustctl_basic_type struct and
+ * _ustctl_basic_type union.
+ */
+static bool match_ustctl_field_basic_type(struct ustctl_basic_type *first,
+			struct ustctl_basic_type *second)
+{
+	return match_ustctl_field_raw_basic_type(first->atype, &first->u.basic,
+				second->atype, &second->u.basic);
+}
+
+int match_ustctl_field(struct ustctl_field *first, struct ustctl_field *second)
+{
+	/* Check the name of the field is identical. */
+	if (strncmp(first->name, second->name, LTTNG_UST_SYM_NAME_LEN)) {
+		goto no_match;
+	}
+
+	/* Check the field type is identical. */
+	if (first->type.atype != second->type.atype) {
+		goto no_match;
+	}
+
+	/* Check the field layout. */
+	switch (first->type.atype) {
+	case ustctl_atype_integer:
+	case ustctl_atype_enum:
+	case ustctl_atype_string:
+	case ustctl_atype_float:
+		if (!match_ustctl_field_raw_basic_type(first->type.atype,
+					&first->type.u.basic, second->type.atype,
+					&second->type.u.basic)) {
+			goto no_match;
+		}
+		break;
+	case ustctl_atype_sequence:
+		/* Match element type of the sequence. */
+		if (!match_ustctl_field_basic_type(&first->type.u.sequence.elem_type,
+					&second->type.u.sequence.elem_type)) {
+			goto no_match;
+		}
+
+		/* Match length type of the sequence. */
+		if (!match_ustctl_field_basic_type(&first->type.u.sequence.length_type,
+					&second->type.u.sequence.length_type)) {
+			goto no_match;
+		}
+
+		break;
+	case ustctl_atype_array:
+		/* Match element type of the array. */
+		if (!match_ustctl_field_basic_type(&first->type.u.array.elem_type,
+					&second->type.u.array.elem_type)) {
+			goto no_match;
+		}
+
+		/* Match length of the array. */
+		if (first->type.u.array.length != second->type.u.array.length) {
+			goto no_match;
+		}
+
+		break;
+	case ustctl_atype_variant:
+		/* Compare number of choice of the variants. */
+		if (first->type.u.variant.nr_choices !=
+					second->type.u.variant.nr_choices) {
+			goto no_match;
+		}
+
+		/* Compare tag name of the variants. */
+		if (strncmp(first->type.u.variant.tag_name,
+					second->type.u.variant.tag_name,
+					LTTNG_UST_SYM_NAME_LEN)) {
+			goto no_match;
+		}
+
+		break;
+	case ustctl_atype_struct:
+		/* Compare number of fields of the structs. */
+		if (first->type.u._struct.nr_fields != second->type.u._struct.nr_fields) {
+			goto no_match;
+		}
+
+		break;
+	default:
+		goto no_match;
+	}
+
+	return true;
+
+no_match:
+	return false;
+}

--- a/src/bin/lttng-sessiond/ust-field-utils.h
+++ b/src/bin/lttng-sessiond/ust-field-utils.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2018 - Francis Deslauriers francis.deslauriers@efficios.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef LTTNG_UST_FIELD_UTILS_H
+#define LTTNG_UST_FIELD_UTILS_H
+
+#include "ust-ctl.h"
+
+/*
+ * Compare two UST fields.
+ * Return 1 if both fields have identical definition, 0 otherwise.
+ */
+int match_ustctl_field(struct ustctl_field *first, struct ustctl_field *second);
+
+#endif /* LTTNG_UST_FIELD_UTILS_H */

--- a/src/bin/lttng-sessiond/ust-registry.c
+++ b/src/bin/lttng-sessiond/ust-registry.c
@@ -558,8 +558,8 @@ struct ust_registry_enum *
 	struct lttng_ht_iter iter;
 
 	cds_lfht_lookup(session->enums->ht,
-			ht_hash_enum((void *) &reg_enum_lookup, lttng_ht_seed),
-			ht_match_enum, &reg_enum_lookup, &iter.iter);
+			ht_hash_enum((void *) reg_enum_lookup, lttng_ht_seed),
+			ht_match_enum, reg_enum_lookup, &iter.iter);
 	node = lttng_ht_iter_get_node_str(&iter);
 	if (!node) {
 	        goto end;

--- a/tests/fast_regression
+++ b/tests/fast_regression
@@ -21,6 +21,7 @@ regression/tools/regen-statedump/test_ust
 regression/ust/before-after/test_before_after
 regression/ust/buffers-pid/test_buffers_pid
 regression/ust/multi-session/test_multi_session
+regression/ust/multi-lib/test_multi_lib
 regression/ust/nprocesses/test_nprocesses
 regression/ust/overlap/test_overlap
 regression/ust/java-jul/test_java_jul

--- a/tests/regression/ust/Makefile.am
+++ b/tests/regression/ust/Makefile.am
@@ -3,7 +3,7 @@ SUBDIRS = nprocesses high-throughput low-throughput before-after multi-session \
 		overlap buffers-pid linking daemon exit-fast fork libc-wrapper \
 		periodical-metadata-flush java-jul java-log4j python-logging \
 		getcpu-override clock-override type-declarations \
-		rotation-destroy-flush blocking
+		rotation-destroy-flush blocking multi-lib
 
 if HAVE_OBJCOPY
 SUBDIRS += baddr-statedump ust-dl

--- a/tests/regression/ust/multi-lib/Makefile.am
+++ b/tests/regression/ust/multi-lib/Makefile.am
@@ -1,0 +1,127 @@
+noinst_SCRIPTS = test_multi_lib
+noinst_PROGRAMS = exec-bare exec-callsites exec-probes
+
+exec_callsites_SOURCES = multi-lib-test.c callsites.c
+exec_callsites_LDFLAGS = -ldl -lpopt
+exec_callsites_CFLAGS = -DCALLSITES
+
+exec_probes_SOURCES = multi-lib-test.c
+exec_probes_LDFLAGS = -ldl -lpopt -llttng-ust
+exec_probes_LDADD = probes.o
+exec_probes_CFLAGS = -DPROBES
+
+exec_bare_SOURCES = multi-lib-test.c
+exec_bare_LDFLAGS = -ldl -lpopt
+exec_bare_CFLAGS = -DBARE
+
+PROBES_SRC=probes.c probes.h
+PROBES_LDF=-shared -module -llttng-ust -avoid-version -rpath $(abs_builddir)/.libs/
+PROBES_CF=-c -I$(srcdir)/
+
+probes.o: probes.c probes.h
+	$(CC) $(PROBES_CF) -o $@ $<
+
+noinst_LTLIBRARIES = libprobes_a.la libprobes_a_prime.la \
+			libprobes_b.la libprobes_c.la libprobes_c_prime.la \
+			libprobes_d.la libprobes_e.la libprobes_f.la \
+			libprobes_g.la libprobes_h.la libprobes_i.la \
+			libprobes_j.la libprobes_k.la libprobes_l.la \
+			libprobes_m.la libprobes_n.la libprobes_o.la \
+			libprobes_p.la
+
+noinst_LTLIBRARIES += libcallsites_a.la libcallsites_b.la
+noinst_LTLIBRARIES += libcallsites_probes_a.la libcallsites_probes_b.la
+
+CALLSITES_SRC=callsites.c callsites.h
+CALLSITES_LDF=-shared -module -llttng-ust -avoid-version -rpath $(abs_builddir)/.libs/
+CALLSITES_CF=-c -I.
+
+libprobes_a_la_SOURCES = $(PROBES_SRC)
+libprobes_a_la_LDFLAGS = $(PROBES_LDF)
+libprobes_a_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_A
+
+libprobes_a_prime_la_SOURCES = $(PROBES_SRC)
+libprobes_a_prime_la_LDFLAGS = $(PROBES_LDF)
+libprobes_a_prime_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_A
+
+libprobes_b_la_SOURCES = $(PROBES_SRC)
+libprobes_b_la_LDFLAGS = $(PROBES_LDF)
+libprobes_b_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_B
+
+libprobes_c_la_SOURCES = $(PROBES_SRC)
+libprobes_c_la_LDFLAGS = $(PROBES_LDF)
+libprobes_c_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_C
+
+libprobes_c_prime_la_SOURCES = $(PROBES_SRC)
+libprobes_c_prime_la_LDFLAGS = $(PROBES_LDF)
+libprobes_c_prime_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_C
+
+libprobes_d_la_SOURCES = $(PROBES_SRC)
+libprobes_d_la_LDFLAGS = $(PROBES_LDF)
+libprobes_d_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_D
+
+libprobes_e_la_SOURCES = $(PROBES_SRC)
+libprobes_e_la_LDFLAGS = $(PROBES_LDF)
+libprobes_e_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_E
+
+libprobes_f_la_SOURCES = $(PROBES_SRC)
+libprobes_f_la_LDFLAGS = $(PROBES_LDF)
+libprobes_f_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_F
+
+libprobes_g_la_SOURCES = $(PROBES_SRC)
+libprobes_g_la_LDFLAGS = $(PROBES_LDF)
+libprobes_g_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_G
+
+libprobes_h_la_SOURCES = $(PROBES_SRC)
+libprobes_h_la_LDFLAGS = $(PROBES_LDF)
+libprobes_h_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_H
+
+libprobes_i_la_SOURCES = $(PROBES_SRC)
+libprobes_i_la_LDFLAGS = $(PROBES_LDF)
+libprobes_i_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_I
+
+libprobes_j_la_SOURCES = $(PROBES_SRC)
+libprobes_j_la_LDFLAGS = $(PROBES_LDF)
+libprobes_j_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_J
+
+libprobes_k_la_SOURCES = $(PROBES_SRC)
+libprobes_k_la_LDFLAGS = $(PROBES_LDF)
+libprobes_k_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_K
+
+libprobes_l_la_SOURCES = $(PROBES_SRC)
+libprobes_l_la_LDFLAGS = $(PROBES_LDF)
+libprobes_l_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_L
+
+libprobes_m_la_SOURCES = $(PROBES_SRC)
+libprobes_m_la_LDFLAGS = $(PROBES_LDF)
+libprobes_m_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_M
+
+libprobes_n_la_SOURCES = $(PROBES_SRC)
+libprobes_n_la_LDFLAGS = $(PROBES_LDF)
+libprobes_n_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_N
+
+libprobes_o_la_SOURCES = $(PROBES_SRC)
+libprobes_o_la_LDFLAGS = $(PROBES_LDF)
+libprobes_o_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_O
+
+libprobes_p_la_SOURCES = $(PROBES_SRC)
+libprobes_p_la_LDFLAGS = $(PROBES_LDF)
+libprobes_p_la_CFLAGS = $(PROBES_CF) -DACTIVATE_PROBES_P
+
+libcallsites_a_la_SOURCES = $(CALLSITES_SRC)
+libcallsites_a_la_LDFLAGS = $(CALLSITES_LDF)
+libcallsites_a_la_CFLAGS = $(CALLSITES_CF)
+
+libcallsites_b_la_SOURCES = $(CALLSITES_SRC)
+libcallsites_b_la_LDFLAGS = $(CALLSITES_LDF)
+libcallsites_b_la_CFLAGS = $(CALLSITES_CF)
+
+libcallsites_probes_a_la_SOURCES = $(CALLSITES_SRC) $(PROBES_SRC)
+libcallsites_probes_a_la_LDFLAGS = $(CALLSITES_LDF)
+libcallsites_probes_a_la_CFLAGS = $(CALLSITES_CF) -DACTIVATE_PROBES_A
+
+libcallsites_probes_b_la_SOURCES = $(CALLSITES_SRC) $(PROBES_SRC)
+libcallsites_probes_b_la_LDFLAGS = $(CALLSITES_LDF)
+libcallsites_probes_b_la_CFLAGS = $(CALLSITES_CF) -DACTIVATE_PROBES_A
+
+CLEANFILES=probes.o

--- a/tests/regression/ust/multi-lib/README
+++ b/tests/regression/ust/multi-lib/README
@@ -1,0 +1,30 @@
+Those test cases are designed to test the support for loading and unloading
+probe providers and callsites at run time during tracing. One test case also
+tests the event payload comparaison functions.
+
+Testing build artefacts
+------------------------
+
+./exec-callsites
+	Test binary built with tracepoint callsites only
+
+./exec-probes
+	Test binary built with tracepoint probes only
+
+./exec-bare
+	Test binary built with no LTTng UST elements
+
+/.libs/libprobe_X.so:
+	Libraries containing slight variations of probe providers for the same
+	tracepoint name. Note that the file /.libs/libprobes_a_prime.so has the same
+	content as .libs/libprobes_a.so likewise for .libs/libprobes_c_prime.so
+
+/.libs/libcallsites_X.so
+  Libraries containing only the tracepoint callsites. The user must dlopen the
+  library and use dlsym to get an handle on the function that calls the
+  tracepoint.
+
+/.libs/libcallsites_probes_X.so
+  Libraries containing tracepoint callsites and probe providers. The user must
+  dlopen the library and use dlsym to get an handle on the function that calls
+  the tracepoint.

--- a/tests/regression/ust/multi-lib/callsites.c
+++ b/tests/regression/ust/multi-lib/callsites.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) - 2018 Francis Deslauriers <francis.deslauriers@efficios.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; version 2.1 of the License.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#define TRACEPOINT_DEFINE
+#define TRACEPOINT_PROBE_DYNAMIC_LINKAGE
+#include "probes.h"
+
+void call_tracepoint(int arg)
+{
+	tracepoint(multi, tp, arg);
+}

--- a/tests/regression/ust/multi-lib/callsites.h
+++ b/tests/regression/ust/multi-lib/callsites.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) - 2018 Francis Deslauriers <francis.deslauriers@efficios.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; version 2.1 of the License.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef CALLSITES_H
+#define CALLSITES_H
+void call_tracepoint(int);
+#endif /* CALLSITES_H */

--- a/tests/regression/ust/multi-lib/multi-lib-test.c
+++ b/tests/regression/ust/multi-lib/multi-lib-test.c
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) - 2018 Francis Deslauriers <francis.deslauriers@efficios.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; version 2.1 of the License.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <popt.h>
+
+#if defined(CALLSITES)
+	#include "callsites.h"
+#endif
+
+void exec_callsite(int arg)
+{
+#if defined(CALLSITES)
+	call_tracepoint(arg);
+#endif
+}
+
+void print_list(void)
+{
+	fprintf(stderr, "Test list (-t X):\n");
+	fprintf(stderr, "\t0: dlopen all libraries pass in arguments and execute "
+			"the callsite. \n");
+	fprintf(stderr, "\t1: simulate the upgrade of a probe provider using dlopen and dlclose \n");
+	fprintf(stderr, "\t2: simulate the upgrade of a library containing the callsites using dlopen and dlclose \n");
+}
+
+
+int dl_open_all(int nb_libraries, char **libraries)
+{
+	int i, ret = 0;
+	void **handles;
+	handles = malloc(nb_libraries * sizeof(void *));
+	if (!handles) {
+		ret = -1;
+		goto error;
+	}
+
+	/* Iterate over the libs to dlopen and save the handles. */
+	for (i = 0; i < nb_libraries; i++) {
+		handles[i] = dlopen(libraries[i], RTLD_NOW);
+		if (!handles[i]) {
+			ret = -1;
+			goto error;
+		}
+	}
+
+	exec_callsite(11111);
+error:
+	return ret;
+}
+
+/*
+ * Takes 2 paths to libraries, dlopen() the first, trace, dlopen() the second,
+ * and dlclose the first to simulate the upgrade of a library.
+ */
+int upgrade_lib(int nb_libraries, char **libraries)
+{
+	int i, ret = 0;
+	void **handles;
+	if (nb_libraries != 2) {
+		ret = -1;
+		goto error;
+	}
+
+	handles = malloc(nb_libraries * sizeof(void *));
+	if (!handles) {
+		ret = -1;
+		goto error;
+	}
+
+	/* Iterate over the libs to dlopen and save the handles. */
+	for (i = 0; i < nb_libraries; i++) {
+		handles[i] = dlopen(libraries[i], RTLD_NOW);
+		if (!handles[i]) {
+			ret = -1;
+			goto error;
+		}
+
+		exec_callsite(i);
+	}
+	ret = dlclose(handles[0]);
+	if (ret) {
+		goto error;
+	}
+
+	exec_callsite(i+1);
+
+error:
+	return ret;
+}
+
+/*
+ * Simulate the upgrade of a library containing a callsite.
+ * Receives two libraries containing callsites for the same tracepoint.
+ */
+int upgrade_callsite(int nb_libraries, char **libraries)
+{
+	int ret = 0;
+	void *handles[2];
+	void (*fct_ptr[2])(int);
+
+	if (nb_libraries != 2) {
+		ret = -1;
+		goto error;
+	}
+
+	/* Load the probes in the first library. */
+	handles[0] = dlopen(libraries[0], RTLD_NOW);
+	if (!handles[0]) {
+		ret = -1;
+		goto error;
+	}
+
+	/*
+	 * Get the pointer to the old function containing the callsite and call it.
+	 */
+	fct_ptr[0] = dlsym(handles[0], "call_tracepoint");
+	if (!fct_ptr[0]) {
+		ret = -1;
+		goto error;
+	}
+
+	fct_ptr[0](11111);
+
+	/* Load the new callsite library. */
+	handles[1] = dlopen(libraries[1], RTLD_NOW);
+	if (!handles[1]) {
+		ret = -1;
+		goto error;
+	}
+
+	/*
+	 * Get the pointer to the new function containing the callsite and call it.
+	 */
+	fct_ptr[1] = dlsym(handles[1], "call_tracepoint");
+	if (!fct_ptr[1]) {
+		ret = -1;
+		goto error;
+	}
+
+	fct_ptr[1](22222);
+
+	/* Unload the old callsite library. */
+	ret = dlclose(handles[0]);
+	if (ret) {
+		goto error;
+	}
+
+	/* Call the function containing the callsite in the new library. */
+	fct_ptr[1](33333);
+
+	ret = dlclose(handles[1]);
+	if (ret) {
+		goto error;
+	}
+
+error:
+	return ret;
+}
+
+int main(int argc, const char **argv) {
+	int c, ret, test = -1, nb_libraries = 0;
+	char **libraries = NULL;
+	poptContext optCon;
+
+	struct poptOption optionsTable[] = {
+		{ "test", 't', POPT_ARG_INT, &test, 0,
+			"Test to run", NULL },
+		{ "list", 'l', 0, 0, 'l',
+			"List of tests (-t X)", NULL },
+		POPT_AUTOHELP
+		{ NULL, 0, 0, NULL, 0 }
+	};
+
+	optCon = poptGetContext(NULL, argc, argv, optionsTable, 0);
+
+	if (argc < 2) {
+		poptPrintUsage(optCon, stderr, 0);
+		ret = -1;
+		goto error;
+	}
+
+	ret = 0;
+
+	while ((c = poptGetNextOpt(optCon)) >= 0) {
+		switch(c) {
+		case 'l':
+			print_list();
+			goto error;
+		}
+	}
+	/* Populate the libraries array with the arguments passed to the process. */
+	while (poptPeekArg(optCon) != NULL) {
+		nb_libraries++;
+		libraries = realloc(libraries, nb_libraries * sizeof(char *));
+		if (!libraries) {
+			ret = -1;
+			goto error;
+		}
+		libraries[nb_libraries-1] = (char*)poptGetArg(optCon);
+	}
+
+	switch(test) {
+	case 0:
+#if defined(CALLSITES)
+		ret = dl_open_all(nb_libraries, libraries);
+#else
+		fprintf(stderr, "Test not implemented for configuration.");
+#endif
+		break;
+	case 1:
+#if defined(CALLSITES)
+		ret = upgrade_lib(nb_libraries, libraries);
+#else
+		fprintf(stderr, "Test not implemented for configuration.");
+#endif
+		break;
+	case 2:
+#if defined(PROBES)
+		ret = upgrade_callsite(nb_libraries, libraries);
+#else
+		fprintf(stderr, "Test not implemented for configuration.");
+#endif
+		break;
+	case 3:
+#if defined(BARE)
+		ret = upgrade_callsite(nb_libraries, libraries);
+#else
+		fprintf(stderr, "Test not implemented for configuration.");
+#endif
+		break;
+	default:
+		fprintf(stderr, "Test %d not implemented\n", test);
+		ret = -1;
+		break;
+	}
+error:
+	poptFreeContext(optCon);
+	return ret;
+}

--- a/tests/regression/ust/multi-lib/probes.c
+++ b/tests/regression/ust/multi-lib/probes.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) - 2018 Francis Deslauriers <francis.deslauriers@efficios.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; version 2.1 of the License.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+#define TRACEPOINT_CREATE_PROBES
+#include "probes.h"

--- a/tests/regression/ust/multi-lib/probes.h
+++ b/tests/regression/ust/multi-lib/probes.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) - 2018 Francis Deslauriers <francis.deslauriers@efficios.com>
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; version 2.1 of the License.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#undef TRACEPOINT_PROVIDER
+#define TRACEPOINT_PROVIDER multi
+
+#undef TRACEPOINT_INCLUDE
+#define TRACEPOINT_INCLUDE "./probes.h"
+
+#if !defined(PROBES_H) || defined(TRACEPOINT_HEADER_MULTI_READ)
+#define PROBES_H
+
+#include <lttng/tracepoint.h>
+
+#if defined(ACTIVATE_PROBES_A)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_integer(unsigned long, arg_long_A, arg)
+    )
+)
+#elif defined(ACTIVATE_PROBES_B)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_integer(unsigned long, arg_long_B, arg)
+        ctf_float(float, arg_float_B, (float) arg)
+    )
+)
+#elif defined(ACTIVATE_PROBES_C)
+TRACEPOINT_ENUM(multi, enum_a,
+    TP_ENUM_VALUES(
+        ctf_enum_value("FIELD_A", 0)
+        ctf_enum_value("FIELD_B", 1)
+        ctf_enum_range("RANGE_C", 2, 10)
+    )
+)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_enum(multi, enum_a, short, enum_short_C,  0)
+        ctf_enum(multi, enum_a, int, enum_int_C,  1)
+        ctf_enum(multi, enum_a, unsigned long, enum_long_C,  2)
+    )
+)
+#elif defined(ACTIVATE_PROBES_D)
+TRACEPOINT_ENUM(multi, enum_a,
+    TP_ENUM_VALUES(
+        ctf_enum_value("FIELD_A", 0)
+        ctf_enum_value("FIELD_B", 1)
+        ctf_enum_range("RANGE_C_PRIME", 2, 10)
+    )
+)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_enum(multi, enum_a, int, enum_int_D,  1)
+        ctf_enum(multi, enum_a, short, enum_short_D,  0)
+        ctf_enum(multi, enum_a, unsigned long, enum_long_D,  2)
+    )
+)
+#elif defined(ACTIVATE_PROBES_E)
+/*
+ * Here we declare tracepoints really similar to one another but are different.
+ * This is meant to test tracepoint comparaison code.
+ */
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_integer(unsigned long, arg_long, arg)
+    )
+)
+#elif defined(ACTIVATE_PROBES_F)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_integer(long, arg_long, arg)
+    )
+)
+#elif defined(ACTIVATE_PROBES_G)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_integer_hex(long, arg_long, arg)
+    )
+)
+#elif defined(ACTIVATE_PROBES_H)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_integer_hex(short, arg_long, arg)
+    )
+)
+#elif defined(ACTIVATE_PROBES_I)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_integer_hex(int, arg_long, arg)
+    )
+)
+#elif defined(ACTIVATE_PROBES_J)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_float(float, arg_float, (float) arg)
+    )
+)
+#elif defined(ACTIVATE_PROBES_K)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_float(double, arg_float, (double) arg)
+    )
+)
+#elif defined(ACTIVATE_PROBES_L)
+TRACEPOINT_ENUM(multi, enum_a,
+    TP_ENUM_VALUES(
+        ctf_enum_value("FIELD_A", 0)
+        ctf_enum_value("FIELD_B", 1)
+        ctf_enum_range("RANGE_C", 2, 10)
+    )
+)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_enum(multi, enum_a, int, enum_int,  1)
+    )
+)
+#elif defined(ACTIVATE_PROBES_M)
+TRACEPOINT_ENUM(multi, enum_a,
+    TP_ENUM_VALUES(
+        ctf_enum_value("FIELD_A", 0)
+        ctf_enum_value("FIELD_B", 1)
+        ctf_enum_range("RANGE_C", 2, 10)
+    )
+)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_enum(multi, enum_a, long, enum_int,  1)
+    )
+)
+#elif defined(ACTIVATE_PROBES_N)
+TRACEPOINT_ENUM(multi, enum_a,
+    TP_ENUM_VALUES(
+        ctf_enum_value("FIELD_A", 0)
+        ctf_enum_value("FIELD_B", 1)
+        ctf_enum_range("RANGE_C", 2, 10)
+    )
+)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_enum(multi, enum_a, short, enum_int,  1)
+    )
+)
+#elif defined(ACTIVATE_PROBES_O)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_string(arg_string, "string")
+    )
+)
+#elif defined(ACTIVATE_PROBES_P)
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+        ctf_string(my_arg_string, "string")
+    )
+)
+#else
+TRACEPOINT_EVENT(multi, tp,
+    TP_ARGS(unsigned long, arg),
+    TP_FIELDS(
+    )
+)
+#endif
+
+#endif /* PROBES_H */
+
+#include <lttng/tracepoint-event.h>

--- a/tests/regression/ust/multi-lib/test_multi_lib
+++ b/tests/regression/ust/multi-lib/test_multi_lib
@@ -1,0 +1,286 @@
+#!/bin/bash
+#
+# Copyright (C) - 2018 Francis Deslauriers <francis.deslauriers@efficios.com>
+#
+# This library is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; version 2.1 of the License.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+
+TEST_DESC="UST - Dynamic loading and unloading of libraries"
+
+CURDIR=$(dirname "$0")/
+TESTDIR=$CURDIR/../../..
+SESSION_NAME="multi_lib"
+
+EXEC_CALLSITES_NAME=$CURDIR/exec-callsites
+EXEC_PROBES_NAME=$CURDIR/exec-probes
+EXEC_BARE_NAME=$CURDIR/exec-bare
+SO_DIR=$CURDIR/.libs/
+SO_PROBES_A=$SO_DIR/libprobes_a.so
+SO_PROBES_A_PRIME=$SO_DIR/libprobes_a_prime.so
+SO_PROBES_B=$SO_DIR/libprobes_b.so
+SO_PROBES_C=$SO_DIR/libprobes_c.so
+SO_PROBES_C_PRIME=$SO_DIR/libprobes_c_prime.so
+SO_PROBES_D=$SO_DIR/libprobes_d.so
+SO_CALLSITE_A=$SO_DIR/libcallsites_a.so
+SO_CALLSITE_B=$SO_DIR/libcallsites_b.so
+SO_CALLSITE_PROBES_A=$SO_DIR/libcallsites_probes_a.so
+SO_CALLSITE_PROBES_B=$SO_DIR/libcallsites_probes_b.so
+
+NUM_TESTS=62
+
+source "$TESTDIR/utils/utils.sh"
+
+test_dlopen_same_provider_name_same_event()
+{
+	local event_name="multi:tp"
+	diag "dlopen 2 providers, same event name, same payload"
+
+	enable_ust_lttng_event_ok $SESSION_NAME "$event_name"
+
+	start_lttng_tracing_ok $SESSION_NAME
+
+	$EXEC_CALLSITES_NAME -t 0 "$SO_PROBES_A" "$SO_PROBES_A_PRIME"
+
+	stop_lttng_tracing_ok $SESSION_NAME
+
+	# Expect 2 identical events in the trace
+	trace_match_only $event_name 2 "$TRACE_PATH"
+
+	# Expect a single event ID in the metadata
+	validate_metadata_event $event_name 1 "$TRACE_PATH"
+
+	return $?
+}
+
+test_dlopen_same_provider_name_different_event()
+{
+	local event_name="multi:tp"
+	# Regular expression for event tp with one argument: arg_long
+	local event_a_payload_exp="^.*$event_name.*arg_long_A.*"
+	# Regular expression for event tp with two arguments: arg_long and
+	# arg_float
+	local event_b_payload_exp="^.*$event_name.*arg_long_B.*arg_float_B.*"
+	diag "dlopen 2 providers, same event name, different payload"
+
+	enable_ust_lttng_event_ok $SESSION_NAME "$event_name"
+
+	start_lttng_tracing_ok $SESSION_NAME
+
+	$EXEC_CALLSITES_NAME -t 0 "$SO_PROBES_A" "$SO_PROBES_B"
+
+	stop_lttng_tracing_ok $SESSION_NAME
+
+	# Expect 2 identical events in the trace
+	trace_match_only $event_name 2 "$TRACE_PATH"
+
+	# Expect 2 events ID in the metadata
+	validate_metadata_event $event_name 2 "$TRACE_PATH"
+
+	# Expect 2 events with different payloads
+	validate_trace_exp "$event_a_payload_exp" "$TRACE_PATH"
+	validate_trace_exp "$event_b_payload_exp" "$TRACE_PATH"
+
+	return $?
+}
+
+test_dlopen_same_provider_name_same_enum()
+{
+	local event_name="multi:tp"
+	diag "dlopen 2 providers, same event name, same enum definition"
+
+	enable_ust_lttng_event_ok $SESSION_NAME "$event_name"
+
+	start_lttng_tracing_ok $SESSION_NAME
+
+	$EXEC_CALLSITES_NAME -t 0 "$SO_PROBES_C" "$SO_PROBES_C_PRIME"
+
+	stop_lttng_tracing_ok $SESSION_NAME
+
+	# Expect 2 identical events in the trace
+	trace_match_only $event_name 2 "$TRACE_PATH"
+
+	# Expect 2 events ID in the metadata
+	validate_metadata_event $event_name 1 "$TRACE_PATH"
+
+	return $?
+}
+
+test_dlopen_same_provider_name_different_enum()
+{
+	local event_name="multi:tp"
+	# Regular expression for event tp with one argument: arg_long
+	local event_c_payload_exp="^.*$event_name.*enum_int_C.*"
+	# Regular expression for event tp with two arguments: arg_long and
+	# arg_float
+	local event_d_payload_exp="^.*$event_name.*enum_int_D.*"
+	diag "dlopen 2 providers, same event name, different enum definition"
+
+	enable_ust_lttng_event_ok $SESSION_NAME "$event_name"
+
+	start_lttng_tracing_ok $SESSION_NAME
+
+	$EXEC_CALLSITES_NAME -t 0 "$SO_PROBES_C" "$SO_PROBES_D"
+
+	stop_lttng_tracing_ok $SESSION_NAME
+
+	# Expect 2 identical events in the trace
+	trace_match_only $event_name 2 "$TRACE_PATH"
+
+	# Expect 2 events ID in the metadata
+	validate_metadata_event $event_name 2 "$TRACE_PATH"
+
+	# Expect 2 events with different payloads
+	validate_trace_exp "$event_c_payload_exp" "$TRACE_PATH"
+	validate_trace_exp "$event_d_payload_exp" "$TRACE_PATH"
+
+	return $?
+}
+
+test_upgrade_probes_dlopen_dclose()
+{
+	local event_name="multi:tp"
+	diag "Upgrade probe provider using dlopen/dlclose during tracing"
+
+	enable_ust_lttng_event_ok $SESSION_NAME "$event_name"
+
+	start_lttng_tracing_ok $SESSION_NAME
+
+	$EXEC_CALLSITES_NAME -t 1 "$SO_PROBES_A" "$SO_PROBES_B"
+
+	stop_lttng_tracing_ok $SESSION_NAME
+
+	# Expect 4 identical events in the trace
+	trace_match_only $event_name 4 "$TRACE_PATH"
+
+	# Expect 2 events ID in the metadata
+	validate_metadata_event $event_name 2 "$TRACE_PATH"
+
+	return $?
+}
+
+test_upgrade_callsites_dlopen_dclose()
+{
+	local event_name="multi:tp"
+	diag "Upgrade callsite using dlopen/dlclose during tracing"
+
+	enable_ust_lttng_event_ok $SESSION_NAME "$event_name"
+
+	start_lttng_tracing_ok $SESSION_NAME
+
+	$EXEC_PROBES_NAME -t 2 "$SO_CALLSITE_A" "$SO_CALLSITE_B"
+
+	stop_lttng_tracing_ok $SESSION_NAME
+
+	# Expect 3 identical events in the trace
+	trace_match_only $event_name 3 "$TRACE_PATH"
+
+	# Expect 1 events ID in the metadata
+	validate_metadata_event $event_name 1 "$TRACE_PATH"
+
+	return $?
+}
+
+test_upgrade_callsites_probes_dlopen_dclose()
+{
+	local event_name="multi:tp"
+	diag "Upgrade callsite and probes using dlopen/dlclose during tracing"
+
+	enable_ust_lttng_event_ok $SESSION_NAME "$event_name"
+
+	start_lttng_tracing_ok $SESSION_NAME
+
+	$EXEC_BARE_NAME -t 3 "$SO_CALLSITE_PROBES_A" "$SO_CALLSITE_PROBES_B"
+
+	stop_lttng_tracing_ok $SESSION_NAME
+
+	# Expect 4 events in the trace.
+	# 1 event before the dlopen of the new lib
+	# 2 events while the 2 libs are loaded
+	# 1 event after the dlclose of the old lib
+	trace_match_only $event_name 4 "$TRACE_PATH"
+
+	# Expect 1 events ID in the metadata
+	validate_metadata_event $event_name 1 "$TRACE_PATH"
+
+	return $?
+}
+
+test_event_field_comparaison()
+{
+	local event_name="multi:tp"
+	diag "Load mutliple events with slight variations in the field descriptions."
+
+	local library_prefix="libprobes_"
+	local nb_libs=0
+	local library_list=" "
+	# Concatenate all the probe libraries in a string.
+	for postfix in {a..p}; do
+		library_list="$library_list $SO_DIR/$library_prefix$postfix.so"
+		let nb_libs+=1
+	done
+
+	enable_ust_lttng_event_ok $SESSION_NAME "$event_name"
+
+	start_lttng_tracing_ok $SESSION_NAME
+
+	$EXEC_CALLSITES_NAME -t 0 $library_list
+
+	stop_lttng_tracing_ok $SESSION_NAME
+
+	# Expect $nb_libs identical events in the trace
+	trace_match_only $event_name $nb_libs "$TRACE_PATH"
+
+	# Expect $nb_libs events ID in the metadata
+	validate_metadata_event $event_name $nb_libs "$TRACE_PATH"
+
+	return $?
+}
+
+
+plan_tests $NUM_TESTS
+
+print_test_banner "$TEST_DESC"
+
+TESTS=(
+	"test_dlopen_same_provider_name_same_event"
+	"test_dlopen_same_provider_name_different_event"
+	"test_dlopen_same_provider_name_different_enum"
+	"test_dlopen_same_provider_name_same_enum"
+	"test_event_field_comparaison"
+	"test_upgrade_probes_dlopen_dclose"
+	"test_upgrade_callsites_dlopen_dclose"
+	"test_upgrade_callsites_probes_dlopen_dclose"
+)
+
+TEST_COUNT=${#TESTS[@]}
+i=0
+
+start_lttng_sessiond
+
+while [ "$i" -lt "$TEST_COUNT" ]; do
+
+	TRACE_PATH=$(mktemp -d)
+
+	create_lttng_session_ok $SESSION_NAME "$TRACE_PATH"
+
+	# Execute test
+	${TESTS[$i]}
+
+	destroy_lttng_session_ok $SESSION_NAME
+
+	rm -rf "$TRACE_PATH"
+
+	let "i++"
+done
+
+stop_lttng_sessiond

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -63,6 +63,7 @@ UST_DATA_TRACE=$(top_builddir)/src/bin/lttng-sessiond/trace-ust.$(OBJEXT) \
 	       $(top_builddir)/src/bin/lttng-sessiond/utils.$(OBJEXT) \
 		   $(top_builddir)/src/bin/lttng-sessiond/buffer-registry.$(OBJEXT) \
 		   $(top_builddir)/src/bin/lttng-sessiond/ust-registry.$(OBJEXT) \
+		   $(top_builddir)/src/bin/lttng-sessiond/ust-field-utils.$(OBJEXT) \
 		   $(top_builddir)/src/bin/lttng-sessiond/ust-metadata.$(OBJEXT) \
 		   $(top_builddir)/src/bin/lttng-sessiond/ust-app.$(OBJEXT) \
 		   $(top_builddir)/src/bin/lttng-sessiond/ust-consumer.$(OBJEXT) \

--- a/tests/utils/utils.sh
+++ b/tests/utils/utils.sh
@@ -1470,7 +1470,7 @@ function validate_trace_exp()
 	which $BABELTRACE_BIN >/dev/null
 	skip $? -ne 0 "Babeltrace binary not found. Skipping trace validation"
 
-	traced=$($BABELTRACE_BIN $trace_path 2>/dev/null | grep ${event_exp} | wc -l)
+	traced=$($BABELTRACE_BIN $trace_path 2>/dev/null | grep --extended-regexp ${event_exp} | wc -l)
 	if [ "$traced" -ne 0 ]; then
 		pass "Validate trace for expression '${event_exp}', $traced events"
 	else
@@ -1489,7 +1489,7 @@ function validate_trace_only_exp()
 	which $BABELTRACE_BIN >/dev/null
 	skip $? -ne 0 "Babeltrace binary not found. Skipping trace matches"
 
-	local count=$($BABELTRACE_BIN $trace_path | grep ${event_exp} | wc -l)
+	local count=$($BABELTRACE_BIN $trace_path | grep --extended-regexp ${event_exp} | wc -l)
 	local total=$($BABELTRACE_BIN $trace_path | wc -l)
 
 	if [ "$count" -ne 0 ] && [ "$total" -eq "$count" ]; then

--- a/tests/utils/utils.sh
+++ b/tests/utils/utils.sh
@@ -1356,6 +1356,29 @@ function add_context_kernel_fail()
 	add_context_lttng 1 -k "$@"
 }
 
+function validate_metadata_event ()
+{
+	local event_name=$1
+	local nr_event_id=$2
+	local trace_path=$3
+
+	local metadata_file=$(find $trace_path | grep metadata)
+	local metadata_path=$(dirname $metadata_file)
+
+	which $BABELTRACE_BIN >/dev/null
+	skip $? -ne 0 "Babeltrace binary not found. Skipping trace matches"
+
+	local count=$($BABELTRACE_BIN --output-format=ctf-metadata $metadata_path | grep $event_name | wc -l)
+
+	if [ "$count" -ne "$nr_event_id" ]; then
+		fail "Metadata match with the metadata of $count event(s) named $event_name"
+		diag "$count matching event id found in metadata"
+	else
+		pass "Metadata match with the metadata of $count event(s) named $event_name"
+	fi
+
+}
+
 function trace_matches ()
 {
 	local event_name=$1


### PR DESCRIPTION
This patch set allows for multiple probes with the same name to be hooked on the same callsite. We now compare probes by doing a deep compare of each field. If two events are _exactly_ the same then the same event ID will be used, if they are different a new event ID is created.

When used with this[ UST patch set](https://github.com/frdeso/lttng-ust/tree/dlclose-support), it is possible to dlclose probe provider and callsite libraries during tracing.

This PR also includes regression tests for both the deep comparaison and the newly added dlclose capability.