### PR TITLE
Fix: test_ust-dl is generated at configure-time

### DIFF
--- a/tests/regression/ust/ust-dl/Makefile.am
+++ b/tests/regression/ust/ust-dl/Makefile.am
@@ -67,7 +67,7 @@ libtp.so: libtp.la
 	@cp -f .libs/libtp.so libtp.so
 
 noinst_SCRIPTS = test_ust-dl test_ust-dl.py
-EXTRA_DIST = test_ust-dl test_ust-dl.py
+EXTRA_DIST = test_ust-dl.py
 
 all-local: libfoo.so libbar.so libzzz.so libtp.so
 	@if [ x"$(srcdir)" != x"$(builddir)" ]; then \


### PR DESCRIPTION
This file should not be in EXTRA_DIST as it's generated by autoconf and
will thus be available directly in the out-of-tree build directory.

Previously, I was witnessing this error message when building out-of-tree:
```
cp: cannot stat '/home/frdeso/projets/lttng/tools/tests/regression/ust/ust-dl/test_ust-dl': No such file or directory
```

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>