### PR TITLE
Tests: Fix: arm64 use sys_openat instead of sys_open

### DIFF
--- a/tests/regression/kernel/test_syscall
+++ b/tests/regression/kernel/test_syscall
@@ -152,16 +152,16 @@ function test_syscall_single()
 
 	create_lttng_session_ok $SESSION_NAME $TRACE_PATH
 
-	lttng_enable_kernel_syscall_ok $SESSION_NAME "open"
+	lttng_enable_kernel_syscall_ok $SESSION_NAME "openat"
 
 	trace_testapp
 
 	# ensure all events are in the trace.
-	validate_trace_exp "-e syscall_entry_open: -e compat_syscall_entry_open:" $TRACE_PATH
-	validate_trace_exp "-e syscall_exit_open: -e compat_syscall_exit_open:" $TRACE_PATH
+	validate_trace_exp "-e syscall_entry_openat: -e compat_syscall_entry_openat:" $TRACE_PATH
+	validate_trace_exp "-e syscall_exit_openat: -e compat_syscall_exit_openat:" $TRACE_PATH
 
 	# ensure trace only contains those.
-	validate_trace_only_exp "-e syscall_entry_open: -e compat_syscall_entry_open: -e syscall_exit_open: -e compat_syscall_exit_open:" $TRACE_PATH
+	validate_trace_only_exp "-e syscall_entry_openat: -e compat_syscall_entry_openat: -e syscall_exit_openat: -e compat_syscall_exit_openat:" $TRACE_PATH
 
 	destroy_lttng_session_ok $SESSION_NAME
 
@@ -177,19 +177,19 @@ function test_syscall_two()
 
 	create_lttng_session_ok $SESSION_NAME $TRACE_PATH
 
-	lttng_enable_kernel_syscall_ok $SESSION_NAME "open"
+	lttng_enable_kernel_syscall_ok $SESSION_NAME "openat"
 	lttng_enable_kernel_syscall_ok $SESSION_NAME "close"
 
 	trace_testapp
 
 	# ensure all events are in the trace.
-	validate_trace_exp "-e syscall_entry_open: -e compat_syscall_entry_open:" $TRACE_PATH
-	validate_trace_exp "-e syscall_exit_open: -e compat_syscall_exit_open:" $TRACE_PATH
+	validate_trace_exp "-e syscall_entry_openat: -e compat_syscall_entry_openat:" $TRACE_PATH
+	validate_trace_exp "-e syscall_exit_openat: -e compat_syscall_exit_openat:" $TRACE_PATH
 	validate_trace_exp "-e syscall_entry_close: -e compat_syscall_entry_close:" $TRACE_PATH
 	validate_trace_exp "-e syscall_exit_close: -e compat_syscall_exit_close:" $TRACE_PATH
 
 	# ensure trace only contains those.
-	validate_trace_only_exp "-e syscall_entry_open: -e compat_syscall_entry_open: -e syscall_exit_open: -e compat_syscall_exit_open: -e syscall_entry_close: -e compat_syscall_entry_close: -e syscall_exit_close: -e compat_syscall_exit_close:" $TRACE_PATH
+	validate_trace_only_exp "-e syscall_entry_openat: -e compat_syscall_entry_openat: -e syscall_exit_openat: -e compat_syscall_exit_openat: -e syscall_entry_close: -e compat_syscall_entry_close: -e syscall_exit_close: -e compat_syscall_exit_close:" $TRACE_PATH
 
 	destroy_lttng_session_ok $SESSION_NAME
 
@@ -211,8 +211,8 @@ function test_syscall_all()
 	trace_testapp
 
 	# ensure at least open and close are there.
-	validate_trace_exp "-e syscall_entry_open: -e compat_syscall_entry_open:" $TRACE_PATH
-	validate_trace_exp "-e syscall_exit_open: -e compat_syscall_exit_open:" $TRACE_PATH
+	validate_trace_exp "-e syscall_entry_openat: -e compat_syscall_entry_openat:" $TRACE_PATH
+	validate_trace_exp "-e syscall_exit_openat: -e compat_syscall_exit_openat:" $TRACE_PATH
 	validate_trace_exp "-e syscall_entry_close: -e compat_syscall_entry_close:" $TRACE_PATH
 	validate_trace_exp "-e syscall_exit_close: -e compat_syscall_exit_close:" $TRACE_PATH
 	# trace may contain other syscalls.
@@ -235,12 +235,12 @@ function test_syscall_all_disable_one()
 	lttng_enable_kernel_syscall_ok $SESSION_NAME
 	# try to disable open system call: fails because enabler semantic of
 	# "all syscalls" is not "the open" system call.
-	lttng_disable_kernel_syscall_fail $SESSION_NAME "open"
+	lttng_disable_kernel_syscall_fail $SESSION_NAME "openat"
 
 	trace_testapp
 
-	# ensure "open" syscall is there.
-	validate_trace_exp "-e syscall_entry_open: -e compat_syscall_entry_open: -e syscall_exit_open: -e compat_syscall_exit_open:" $TRACE_PATH
+	# ensure "openat" syscall is there.
+	validate_trace_exp "-e syscall_entry_openat: -e compat_syscall_entry_openat: -e syscall_exit_openat: -e compat_syscall_exit_openat:" $TRACE_PATH
 
 	# ensure "close" syscall is there.
 	validate_trace_exp "-e syscall_entry_close: -e compat_syscall_entry_close:" $TRACE_PATH
@@ -264,13 +264,13 @@ function test_syscall_all_disable_two()
 	lttng_enable_kernel_syscall_ok $SESSION_NAME
 	# try to disable open and close system calls: fails because enabler
 	# semantic of "all syscalls" is not "the open" system call.
-	lttng_disable_kernel_syscall_fail $SESSION_NAME "open"
+	lttng_disable_kernel_syscall_fail $SESSION_NAME "openat"
 	lttng_disable_kernel_syscall_fail $SESSION_NAME "close"
 
 	trace_testapp
 
-	# ensure "open" syscall is there.
-	validate_trace_exp "-e syscall_entry_open: -e compat_syscall_entry_open: -e syscall_exit_open: -e compat_syscall_exit_open:" $TRACE_PATH
+	# ensure "openat" syscall is there.
+	validate_trace_exp "-e syscall_entry_openat: -e compat_syscall_entry_openat: -e syscall_exit_openat: -e compat_syscall_exit_openat:" $TRACE_PATH
 
 	# ensure "close" syscall is there.
 	validate_trace_exp "-e syscall_entry_close: -e compat_syscall_entry_close:" $TRACE_PATH
@@ -328,8 +328,8 @@ function test_syscall_enable_all_disable_all_enable_all()
 	trace_testapp
 
 	# ensure at least open and close are there.
-	validate_trace_exp "-e syscall_entry_open: -e compat_syscall_entry_open:" $TRACE_PATH
-	validate_trace_exp "-e syscall_exit_open: -e compat_syscall_exit_open:" $TRACE_PATH
+	validate_trace_exp "-e syscall_entry_openat: -e compat_syscall_entry_openat:" $TRACE_PATH
+	validate_trace_exp "-e syscall_exit_openat: -e compat_syscall_exit_openat:" $TRACE_PATH
 	validate_trace_exp "-e syscall_entry_close: -e compat_syscall_entry_close:" $TRACE_PATH
 	validate_trace_exp "-e syscall_exit_close: -e compat_syscall_exit_close:" $TRACE_PATH
 	# trace may contain other syscalls.
@@ -377,9 +377,9 @@ function test_syscall_enable_one_disable_one()
 	create_lttng_session_ok $SESSION_NAME $TRACE_PATH
 
 	# enable open system call
-	lttng_enable_kernel_syscall_ok $SESSION_NAME "open"
+	lttng_enable_kernel_syscall_ok $SESSION_NAME "openat"
 	# disable open system call
-	lttng_disable_kernel_syscall_ok $SESSION_NAME "open"
+	lttng_disable_kernel_syscall_ok $SESSION_NAME "openat"
 
 	trace_testapp
 
@@ -401,10 +401,10 @@ function test_syscall_enable_two_disable_two()
 	create_lttng_session_ok $SESSION_NAME $TRACE_PATH
 
 	# enable open and close system calls
-	lttng_enable_kernel_syscall_ok $SESSION_NAME "open"
+	lttng_enable_kernel_syscall_ok $SESSION_NAME "openat"
 	lttng_enable_kernel_syscall_ok $SESSION_NAME "close"
 	# disable open and close system calls
-	lttng_disable_kernel_syscall_ok $SESSION_NAME "open"
+	lttng_disable_kernel_syscall_ok $SESSION_NAME "openat"
 	lttng_disable_kernel_syscall_ok $SESSION_NAME "close"
 
 	trace_testapp
@@ -427,7 +427,7 @@ function test_syscall_enable_two_disable_one()
 	create_lttng_session_ok $SESSION_NAME $TRACE_PATH
 
 	# enable open and close system calls
-	lttng_enable_kernel_syscall_ok $SESSION_NAME "open"
+	lttng_enable_kernel_syscall_ok $SESSION_NAME "openat"
 	lttng_enable_kernel_syscall_ok $SESSION_NAME "close"
 	# disable close system call
 	lttng_disable_kernel_syscall_ok $SESSION_NAME "close"
@@ -435,11 +435,11 @@ function test_syscall_enable_two_disable_one()
 	trace_testapp
 
 	# ensure open is there.
-	validate_trace_exp "-e syscall_entry_open: -e compat_syscall_entry_open:" $TRACE_PATH
-	validate_trace_exp "-e syscall_exit_open: -e compat_syscall_exit_open:" $TRACE_PATH
+	validate_trace_exp "-e syscall_entry_openat: -e compat_syscall_entry_openat:" $TRACE_PATH
+	validate_trace_exp "-e syscall_exit_openat: -e compat_syscall_exit_openat:" $TRACE_PATH
 
 	# ensure trace only contains those.
-	validate_trace_only_exp "-e syscall_entry_open: -e compat_syscall_entry_open: -e syscall_exit_open: -e compat_syscall_exit_open:" $TRACE_PATH
+	validate_trace_only_exp "-e syscall_entry_openat: -e compat_syscall_entry_openat: -e syscall_exit_openat: -e compat_syscall_exit_openat:" $TRACE_PATH
 
 	destroy_lttng_session_ok $SESSION_NAME
 
@@ -455,11 +455,11 @@ function test_syscall_disable_twice()
 
 	create_lttng_session_ok $SESSION_NAME $TRACE_PATH
 
-	lttng_enable_kernel_syscall_ok $SESSION_NAME "open"
+	lttng_enable_kernel_syscall_ok $SESSION_NAME "openat"
 	# First disable will succeed
-	lttng_disable_kernel_syscall_ok $SESSION_NAME "open"
+	lttng_disable_kernel_syscall_ok $SESSION_NAME "openat"
 	# Second disable succeeds too, due to enabler semantic.
-	lttng_disable_kernel_syscall_ok $SESSION_NAME "open"
+	lttng_disable_kernel_syscall_ok $SESSION_NAME "openat"
 
 	destroy_lttng_session_ok $SESSION_NAME
 
@@ -516,7 +516,7 @@ function test_syscall_enable_all_enable_one()
 
 	lttng_enable_kernel_syscall_ok $SESSION_NAME
 	# Enabling an event already enabled succeeds, due to enabler semantic.
-	lttng_enable_kernel_syscall_ok $SESSION_NAME "open"
+	lttng_enable_kernel_syscall_ok $SESSION_NAME "openat"
 
 	destroy_lttng_session_ok $SESSION_NAME
 
@@ -535,7 +535,7 @@ function test_syscall_disable_all_disable_one()
 	lttng_enable_kernel_syscall_ok $SESSION_NAME
 	lttng_disable_kernel_syscall_ok $SESSION_NAME
 	# Disabling an event already disabled fails.
-	lttng_disable_kernel_syscall_fail $SESSION_NAME "open"
+	lttng_disable_kernel_syscall_fail $SESSION_NAME "openat"
 
 	destroy_lttng_session_ok $SESSION_NAME
 
@@ -573,7 +573,7 @@ function test_syscall_enable_channel_disable_one()
 	create_lttng_session_ok $SESSION_NAME $TRACE_PATH
 
 	lttng_enable_kernel_channel_ok $SESSION_NAME $CHANNEL_NAME
-	lttng_disable_kernel_syscall_fail $SESSION_NAME "open" $CHANNEL_NAME
+	lttng_disable_kernel_syscall_fail $SESSION_NAME "openat" $CHANNEL_NAME
 
 	destroy_lttng_session_ok $SESSION_NAME
 

--- a/tests/utils/testapp/gen-syscall-events/gen-syscall-events.c
+++ b/tests/utils/testapp/gen-syscall-events/gen-syscall-events.c
@@ -15,8 +15,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
-#define _LGPL_SOURCE
-
 #include <fcntl.h>
 #include <stdio.h>
 #include <sys/syscall.h>
@@ -59,7 +57,7 @@ int main(int argc, char **argv)
 	 * Start generating syscalls. We use syscall(2) to prevent libc to change
 	 * the underlying syscall. e.g. calling openat(2) instead of open(2).
 	 */
-	fd = syscall(SYS_open, "/proc/cpuinfo", O_RDONLY);
+	fd = syscall(SYS_openat, AT_FDCWD, "/proc/cpuinfo", O_RDONLY);
 	if (fd < 0) {
 		perror("open");
 		ret = -1;


### PR DESCRIPTION
gen-syscall-events is failing to build on arm64 because of the following
error:
```
gen-syscall-events.c: In function ‘main’:
gen-syscall-events.c:35:15: error: ‘SYS_open’ undeclared (first use in
this function)
  fd = syscall(SYS_open, "/proc/cpuinfo", O_RDONLY);
```

SYS_open is not available using the syscall(2) arm64 glibc function.
SYS_openat should be used instead.

Change test app and test cases to use SYS_openat.

Other projects have encountered the same issue:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=758521
https://bugs.launchpad.net/linaro-aarch64/+bug/1100782

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>