### PR TITLE
Add -Wsign-compare to the project's CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1002,7 +1002,7 @@ AM_CONDITIONAL([BUILD_LIB_SESSIOND_COMM], [test x$build_lib_sessiond_comm = xyes
 AM_CONDITIONAL([BUILD_LIB_TESTPOINT], [test x$build_lib_testpoint = xyes])
 AM_CONDITIONAL([BUILD_LIB_UST_CONSUMER], [test x$build_lib_ust_consumer = xyes])
 
-AM_CFLAGS="-Wall -fno-strict-aliasing $PTHREAD_CFLAGS"
+AM_CFLAGS="-Wall -fno-strict-aliasing $PTHREAD_CFLAGS -Wsign-compare"
 AC_SUBST(AM_CFLAGS)
 
 AM_CPPFLAGS="-I\$(top_srcdir)/include -I\$(top_builddir)/include -I\$(top_srcdir)/src -include config.h $AM_CPPFLAGS"


### PR DESCRIPTION
The lttng-tools code base has many erroneous comparisons between
signed and unsigned values.

While some uses are benign, like using a signed integer to loop
between 0 and sizeof(struct some_structure), there are many
cases where the "signed integer" result of a syscall
(e.g. sendmsg, recvmsg, read, write) is compared to an expected
structure size using sizeof, which returns a result of type
size_t.

The following pattern:

ret = sendmsg(...);
if (ret < sizeof(struct some_structure)) {
	/* Handle error. */
}

is common and _unsafe_ if the intention is to check for an error
(-1) and that the operation was completed (ret == sizeof(...)).

Follow-up patches address the various instances of the problem.

The "Clean-up:" prefix is used when the comparison was safe
and the change is mainly done to silence the warning.

The "Fix:" prefix is used when the commit fixes an unsafe
comparison and should be backported to previous versions.