### PR TITLE
Fix: use off_t type for lseek function return value to avoid overflow

### DIFF
--- a/src/bin/lttng-relayd/live.c
+++ b/src/bin/lttng-relayd/live.c
@@ -1483,6 +1483,7 @@ static
 int viewer_get_packet(struct relay_connection *conn)
 {
 	int ret;
+	off_t lseek_ret;
 	char *reply = NULL;
 	struct lttng_viewer_get_packet get_packet_info;
 	struct lttng_viewer_trace_packet reply_header;
@@ -1524,9 +1525,9 @@ int viewer_get_packet(struct relay_connection *conn)
 	}
 
 	pthread_mutex_lock(&vstream->stream->lock);
-	ret = lseek(vstream->stream_fd->fd, be64toh(get_packet_info.offset),
+	lseek_ret = lseek(vstream->stream_fd->fd, be64toh(get_packet_info.offset),
 			SEEK_SET);
-	if (ret < 0) {
+	if (lseek_ret < 0) {
 		PERROR("lseek fd %d to offset %" PRIu64, vstream->stream_fd->fd,
 			be64toh(get_packet_info.offset));
 		goto error;

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -1588,6 +1588,7 @@ static
 int rotate_truncate_stream(struct relay_stream *stream)
 {
 	int ret, new_fd;
+	off_t lseek_ret;
 	uint64_t diff, pos = 0;
 	char buf[FILE_COPY_BUFFER_SIZE];
 
@@ -1614,10 +1615,11 @@ int rotate_truncate_stream(struct relay_stream *stream)
 	 * Rewind the current tracefile to the position at which the rotation
 	 * should have occured.
 	 */
-	ret = lseek(stream->stream_fd->fd,
+	lseek_ret = lseek(stream->stream_fd->fd,
 			stream->pos_after_last_complete_data_index, SEEK_SET);
-	if (ret < 0) {
+	if (lseek_ret < 0) {
 		PERROR("seek truncate stream");
+		ret = -1;
 		goto end;
 	}
 

--- a/src/bin/lttng-sessiond/cmd.c
+++ b/src/bin/lttng-sessiond/cmd.c
@@ -3647,10 +3647,12 @@ static
 int clear_metadata_file(int fd)
 {
 	int ret;
+	off_t lseek_ret;
 
-	ret = lseek(fd, 0, SEEK_SET);
-	if (ret < 0) {
+	lseek_ret = lseek(fd, 0, SEEK_SET);
+	if (lseek_ret < 0) {
 		PERROR("lseek");
+		ret = -1;
 		goto end;
 	}
 

--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -1487,15 +1487,17 @@ LTTNG_HIDDEN
 int utils_truncate_stream_file(int fd, off_t length)
 {
 	int ret;
+	off_t lseek_ret;
 
 	ret = ftruncate(fd, length);
 	if (ret < 0) {
 		PERROR("ftruncate");
 		goto end;
 	}
-	ret = lseek(fd, length, SEEK_SET);
-	if (ret < 0) {
+	lseek_ret = lseek(fd, length, SEEK_SET);
+	if (lseek_ret < 0) {
 		PERROR("lseek");
+		ret = -1;
 		goto end;
 	}
 end:


### PR DESCRIPTION
Context: LTTng is configured in live mode with only one channel, getting
traces for a long-running application (days of uptime)

The trace file gets bigger (many GBs), so the offset (bigger than
int.MaxValue). When getting a packet for such offset, the lseek returns
bigger value than int.MaxValue. This value is stored in a variable "ret" of
type int. This causes an overflow which leads to sending an error to the
viewer (babeltrace), which stops.
[error] get_data_packet: error.
[error] get_data_packet failed
[error] Unknown return code 0

Signed-off-by: Gregory LEOCADIE <g.leocadie@criteo.com>