### PR TITLE
sessiond: rename syscall.h so it does not conflict with system

### DIFF
--- a/src/bin/lttng-sessiond/Makefile.am
+++ b/src/bin/lttng-sessiond/Makefile.am
@@ -31,7 +31,7 @@ lttng_sessiond_SOURCES = utils.c utils.h \
                        agent.c agent.h \
                        save.h save.c \
                        load-session-thread.h load-session-thread.c \
-                       syscall.h syscall.c \
+                       lttng-syscall.h lttng-syscall.c \
                        notification-thread.h notification-thread.c \
                        notification-thread-internal.h \
                        notification-thread-commands.h notification-thread-commands.c \

--- a/src/bin/lttng-sessiond/cmd.c
+++ b/src/bin/lttng-sessiond/cmd.c
@@ -47,7 +47,7 @@
 #include "kernel-consumer.h"
 #include "lttng-sessiond.h"
 #include "utils.h"
-#include "syscall.h"
+#include "lttng-syscall.h"
 #include "agent.h"
 #include "buffer-registry.h"
 #include "notification-thread.h"

--- a/src/bin/lttng-sessiond/lttng-syscall.c
+++ b/src/bin/lttng-sessiond/lttng-syscall.c
@@ -24,7 +24,7 @@
 
 #include "lttng-sessiond.h"
 #include "kernel.h"
-#include "syscall.h"
+#include "lttng-syscall.h"
 #include "utils.h"
 
 /* Global syscall table. */

--- a/src/bin/lttng-sessiond/lttng-syscall.h
+++ b/src/bin/lttng-sessiond/lttng-syscall.h
@@ -15,8 +15,8 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef SYSCALL_H
-#define SYSCALL_H
+#ifndef LTTNG_SYSCALL_H
+#define LTTNG_SYSCALL_H
 
 #include <common/hashtable/hashtable.h>
 #include <lttng/event.h>
@@ -54,4 +54,4 @@ extern struct syscall *syscall_table;
 int syscall_init_table(void);
 ssize_t syscall_table_list(struct lttng_event **events);
 
-#endif /* SYSCALL_H */
+#endif /* LTTNG_SYSCALL_H */

--- a/src/bin/lttng-sessiond/main.c
+++ b/src/bin/lttng-sessiond/main.c
@@ -74,7 +74,7 @@
 #include "notification-thread.h"
 #include "notification-thread-commands.h"
 #include "rotation-thread.h"
-#include "syscall.h"
+#include "lttng-syscall.h"
 #include "agent.h"
 #include "ht-cleanup.h"
 #include "sessiond-config.h"

--- a/src/bin/lttng-sessiond/save.c
+++ b/src/bin/lttng-sessiond/save.c
@@ -32,7 +32,7 @@
 #include "kernel.h"
 #include "save.h"
 #include "session.h"
-#include "syscall.h"
+#include "lttng-syscall.h"
 #include "trace-ust.h"
 #include "agent.h"
 


### PR DESCRIPTION
Signed-off-by: Geneviève Bastien <gbastien+lttng@versatic.net>