### PR TITLE
Perform relayd socket pair cleanup on ctrl socket error.

### DIFF
--- a/src/common/consumer/consumer.c
+++ b/src/common/consumer/consumer.c
@@ -4222,10 +4222,14 @@ int rotate_relay_stream(struct lttng_consumer_local_data *ctx,
 			stream->channel_read_only_attributes.path,
 			stream->chan->current_chunk_id,
 			stream->last_sequence_number);
-	pthread_mutex_unlock(&relayd->ctrl_sock_mutex);
+	if (ret < 0) {
+		ERR("Relayd rotate stream failed. Cleaning up relayd %" PRIu64".", relayd->net_seq_idx);
+		lttng_consumer_cleanup_relayd(relayd);
+	}
 	if (ret) {
 		ERR("Rotate relay stream");
 	}
+	pthread_mutex_unlock(&relayd->ctrl_sock_mutex);
 
 end:
 	return ret;
@@ -4396,6 +4400,10 @@ int rotate_rename_relay(const char *old_path, const char *new_path,
 
 	pthread_mutex_lock(&relayd->ctrl_sock_mutex);
 	ret = relayd_rotate_rename(&relayd->control_sock, old_path, new_path);
+	if (ret < 0) {
+		ERR("Relayd rotate rename failed. Cleaning up relayd %" PRIu64".", relayd->net_seq_idx);
+		lttng_consumer_cleanup_relayd(relayd);
+	}
 	pthread_mutex_unlock(&relayd->ctrl_sock_mutex);
 end:
 	return ret;
@@ -4426,6 +4434,10 @@ int lttng_consumer_rotate_pending_relay(uint64_t session_id,
 
 	pthread_mutex_lock(&relayd->ctrl_sock_mutex);
 	ret = relayd_rotate_pending(&relayd->control_sock, chunk_id);
+	if (ret < 0) {
+		ERR("Relayd rotate pending failed. Cleaning up relayd %" PRIu64".", relayd->net_seq_idx);
+		lttng_consumer_cleanup_relayd(relayd);
+	}
 	pthread_mutex_unlock(&relayd->ctrl_sock_mutex);
 
 end:
@@ -4463,6 +4475,10 @@ int mkdir_relay(const char *path, uint64_t relayd_id)
 
 	pthread_mutex_lock(&relayd->ctrl_sock_mutex);
 	ret = relayd_mkdir(&relayd->control_sock, path);
+	if (ret < 0) {
+		ERR("Relayd mkdir failed. Cleaning up relayd %" PRIu64".", relayd->net_seq_idx);
+		lttng_consumer_cleanup_relayd(relayd);
+	}
 	pthread_mutex_unlock(&relayd->ctrl_sock_mutex);
 
 end:

--- a/src/common/consumer/consumer.h
+++ b/src/common/consumer/consumer.h
@@ -512,6 +512,7 @@ struct consumer_relayd_sock_pair {
 	/* Session id on both sides for the sockets. */
 	uint64_t relayd_session_id;
 	uint64_t sessiond_session_id;
+	struct lttng_consumer_local_data *ctx;
 };
 
 /*
@@ -840,5 +841,6 @@ int lttng_consumer_rotate_pending_relay( uint64_t session_id,
 void lttng_consumer_reset_stream_rotate_state(struct lttng_consumer_stream *stream);
 int lttng_consumer_mkdir(const char *path, uid_t uid, gid_t gid,
 		uint64_t relayd_id);
+void lttng_consumer_cleanup_relayd(struct consumer_relayd_sock_pair *relayd);
 
 #endif /* LIB_CONSUMER_H */


### PR DESCRIPTION
Can be merged into a single commit if needed.