### PR TITLE
Fix: Tests: use -no-pie linker option only when available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,10 @@ AS_IF([test "x$ax_cv___attribute__" = "xyes"],
 
 AX_PTHREAD(,[AC_MSG_ERROR([Could not configure pthreads support])])
 
+# Check if linker has the -no-pie option.
+AX_CHECK_LINK_FLAG([-no-pie], [linker_have_no_pie_option=yes])
+AM_CONDITIONAL([LINKER_HAVE_NO_PIE_OPTION], [test "x$linker_have_no_pie_option" = "xyes"])
+
 AX_LIB_SOCKET_NSL
 
 LT_NO_UNDEFINED=""

--- a/m4/ax_check_link_flag.m4
+++ b/m4/ax_check_link_flag.m4
@@ -1,0 +1,74 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_check_link_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_LINK_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the linker or gives an error.
+#   (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the linker's default flags
+#   when the check is done.  The check is thus made with the flags: "LDFLAGS
+#   EXTRA-FLAGS FLAG".  This can for example be used to force the linker to
+#   issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_LINK_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,COMPILE}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 5
+
+AC_DEFUN([AX_CHECK_LINK_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_ldflags_$4_$1])dnl
+AC_CACHE_CHECK([whether the linker accepts $1], CACHEVAR, [
+  ax_check_save_flags=$LDFLAGS
+  LDFLAGS="$LDFLAGS $4 $1"
+  AC_LINK_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  LDFLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_LINK_FLAGS

--- a/tests/utils/testapp/gen-syscall-events-callstack/Makefile.am
+++ b/tests/utils/testapp/gen-syscall-events-callstack/Makefile.am
@@ -1,5 +1,15 @@
 AM_CFLAGS += -I$(top_srcdir)/tests/utils/
-AM_CFLAGS += -fno-omit-frame-pointer -no-pie
+AM_CFLAGS += -fno-omit-frame-pointer
+#  The feature called Position Independent Execution (PIE) may be enabled by
+#  default on some systems. Supporting this feature for this testapp would
+#  increase the complexity of the testcases using this testapp as it would make
+#  the addresses of functions unpredictable. So we prevent the linker from
+#  using it by using the -no-pie option. If the -no-pie option is not
+#  available, we assume that the PIE is not enabled by default so we do not
+#  need to disable it.
+if LINKER_HAVE_NO_PIE_OPTION
+AM_CFLAGS += -no-pie
+endif
 
 noinst_PROGRAMS = gen-syscall-events-callstack
 gen_syscall_events_callstack_SOURCES = gen-syscall-events-callstack.c


### PR DESCRIPTION
Issue
=====
To keep the userspace callstack tests simple, we want to prevent the
testapp to be linked as a Position Independent Execution (PIE) binary as
it is simpler to resolve the addresses of functions. Some distributions
now ship GCC built with the --enable-default-pie option which turns on
PIE by default. To prevent that, we use the -no-pie linker flag when
building the gen-syscall-events-callstack testapp. The issue is that
this flag is not available on older version of GCC thus triggering an
error when building the project.

```
gcc: error: unrecognized command line option ‘-no-pie’
```

Solution
========
Test for the availability of the -no-pie option at the configure time
and enable it only when found. If the option is unavailable we assume
that the -pie option is not enabled by default thus removing the need to
prevent its usage with -no-pie in the first place.

Known drawbacks
===============
None

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>