### PR TITLE
Implement a file descriptor cache for the relay daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ TAGS
 /tests/unit/test_utils_parse_time_suffix
 /tests/unit/test_utils_expand_path
 /tests/unit/test_notification
+/tests/unit/test_fd_tracker
 kernel_all_events_basic
 kernel_event_basic
 ust_global_event_wildcard

--- a/configure.ac
+++ b/configure.ac
@@ -1087,6 +1087,7 @@ AC_CONFIG_FILES([
 	src/common/health/Makefile
 	src/common/config/Makefile
 	src/common/string-utils/Makefile
+	src/common/fd-tracker/Makefile
 	src/lib/Makefile
 	src/lib/lttng-ctl/Makefile
 	src/lib/lttng-ctl/filter/Makefile

--- a/doc/man/lttng-relayd.8.txt
+++ b/doc/man/lttng-relayd.8.txt
@@ -11,8 +11,9 @@ SYNOPSIS
 --------
 [verse]
 *lttng-relayd* [option:--background | option:--daemonize]
-             [option:--control-port='URL'] [option:--data-port='URL'] [option:--live-port='URL']
-             [option:--output='PATH'] [option:-v | option:-vv | option:-vvv]
+             [option:--control-port='URL'] [option:--data-port='URL'] [option:--fd-pool-size='COUNT']
+             [option:--live-port='URL'] [option:--output='PATH']
+             [option:-v | option:-vv | option:-vvv]
 
 
 DESCRIPTION
@@ -104,6 +105,12 @@ option:-d, option:--daemonize::
     Start as Unix daemon, and close file descriptors (console). Use the
     option:--background option instead to keep the file descriptors
     open.
+
+option:--fd-pool-size='COUNT'::
+    Set the size of the file descritptor pool. This effectively sets a
+    limit on the number of file descriptors that may be kept open
+    simultaneously by the daemon (default: the soft RLIMIT_NOFILE resource
+    limit of the process).
 
 option:-g 'GROUP', option:--group='GROUP'::
     Use 'GROUP' as Unix tracing group (default: `tracing`).

--- a/src/bin/lttng-relayd/Makefile.am
+++ b/src/bin/lttng-relayd/Makefile.am
@@ -34,4 +34,5 @@ lttng_relayd_LDADD = -lurcu-common -lurcu \
 		$(top_builddir)/src/common/health/libhealth.la \
 		$(top_builddir)/src/common/config/libconfig.la \
 		$(top_builddir)/src/common/testpoint/libtestpoint.la \
+		$(top_builddir)/src/common/fd-tracker/libfd-tracker.la \
 		$(top_builddir)/src/lib/lttng-ctl/liblttng-ctl.la

--- a/src/bin/lttng-relayd/Makefile.am
+++ b/src/bin/lttng-relayd/Makefile.am
@@ -22,7 +22,8 @@ lttng_relayd_SOURCES = main.c lttng-relayd.h utils.h utils.c cmd.h \
                        connection.c connection.h \
                        viewer-session.c viewer-session.h \
                        tracefile-array.c tracefile-array.h \
-                       tcp_keep_alive.c tcp_keep_alive.h
+                       tcp_keep_alive.c tcp_keep_alive.h \
+                       index-file.c index-file.h
 
 # link on liblttngctl for check if relayd is already alive.
 lttng_relayd_LDADD = -lurcu-common -lurcu \

--- a/src/bin/lttng-relayd/health-relayd.c
+++ b/src/bin/lttng-relayd/health-relayd.c
@@ -331,8 +331,10 @@ void *thread_manage_health(void *data)
 		goto error;
 	}
 
-	/* Size is set to 1 for the consumer_channel pipe */
-	ret = lttng_poll_create(&events, 2, LTTNG_CLOEXEC);
+	/* Size is set to 2 for the unix socket and quit pipe. */
+	ret = fd_tracker_util_poll_create(the_fd_tracker,
+			"Health management thread epoll", &events, 2,
+			LTTNG_CLOEXEC);
 	if (ret < 0) {
 		ERR("Poll set creation failed");
 		goto error;
@@ -490,7 +492,7 @@ exit:
 	 * other processes using them.
 	 */
 
-	lttng_poll_clean(&events);
+	(void) fd_tracker_util_poll_clean(the_fd_tracker, &events);
 
 	rcu_unregister_thread();
 	return NULL;

--- a/src/bin/lttng-relayd/index-file.c
+++ b/src/bin/lttng-relayd/index-file.c
@@ -1,0 +1,388 @@
+/*
+ * Copyright (C) 2018 - Jérémie Galarneau <jeremie.galarneau@efficios.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "index-file.h"
+#include "lttng-relayd.h"
+
+#include <common/defaults.h>
+#include <common/error.h>
+#include <common/utils.h>
+#include <common/readwrite.h>
+#include <common/fd-tracker/fd-tracker.h>
+#include <common/fd-tracker/utils.h>
+#include <lttng/constant.h>
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <urcu/ref.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+struct relay_index_file {
+	bool suspendable;
+	union {
+		/* Suspendable. */
+		struct fs_handle *handle;
+		/* Unsuspendable. */
+		int fd;
+	} u;
+	uint32_t major;
+	uint32_t minor;
+	uint32_t element_len;
+	struct urcu_ref ref;
+};
+
+/*
+ * Create the index file associated with a trace file.
+ *
+ * Return allocated struct lttng_index_file, NULL on error.
+ */
+struct relay_index_file *relay_index_file_create(const char *path_name,
+		const char *stream_name, uint64_t size, uint64_t count,
+		uint32_t idx_major, uint32_t idx_minor)
+{
+	struct relay_index_file *index_file;
+	struct fs_handle *fs_handle = NULL;
+	int ret, fd = -1;
+	ssize_t size_ret;
+	struct ctf_packet_index_file_hdr hdr;
+	char idx_dir_path[LTTNG_PATH_MAX];
+	char idx_file_path[LTTNG_PATH_MAX];
+	/*
+	 * With the session rotation feature on the relay, we might need to seek
+	 * and truncate a tracefile, so we need read and write access.
+	 */
+	int flags = O_RDWR | O_CREAT | O_TRUNC;
+	/* Open with 660 mode */
+	mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
+
+	index_file = zmalloc(sizeof(*index_file));
+	if (!index_file) {
+		PERROR("allocating relay_index_file");
+		goto error;
+	}
+
+	/*
+	 * The receiving end of the relay daemon is not expected to try
+	 * to append to an index file. It is thus safe to create it as
+	 * suspendable.
+	 */
+	index_file->suspendable = true;
+
+	ret = snprintf(idx_dir_path, sizeof(idx_dir_path), "%s/" DEFAULT_INDEX_DIR,
+			path_name);
+	if (ret < 0) {
+		PERROR("snprintf index path");
+		goto error;
+	}
+
+	/* Create index directory if necessary. */
+	ret = utils_mkdir(idx_dir_path, S_IRWXU | S_IRWXG, -1, -1);
+	if (ret < 0) {
+		if (errno != EEXIST) {
+			PERROR("Index trace directory creation error");
+			goto error;
+		}
+	}
+
+	ret = utils_stream_file_name(idx_file_path, idx_dir_path, stream_name,
+			size, count, DEFAULT_INDEX_FILE_SUFFIX);
+	if (ret < 0) {
+		ERR("Could not build path of index file");
+		goto error;
+	}
+
+	/*
+	 * For tracefile rotation. We need to unlink the old
+	 * file if present to synchronize with the tail of the
+	 * live viewer which could be working on this same file.
+	 * By doing so, any reference to the old index file
+	 * stays valid even if we re-create a new file with the
+	 * same name afterwards.
+	 */
+	unlink(idx_file_path);
+	if (ret < 0 && errno != ENOENT) {
+		PERROR("Failed to unlink index file");
+		goto error;
+	}
+
+	fs_handle = fd_tracker_open_fs_handle(the_fd_tracker, idx_file_path,
+			flags, &mode);
+	if (!fs_handle) {
+		goto error;
+	}
+	index_file->u.handle = fs_handle;
+
+	fd = fs_handle_get_fd(fs_handle);
+	if (fd < 0) {
+		goto error;
+	}
+
+	ctf_packet_index_file_hdr_init(&hdr, idx_major, idx_minor);
+	size_ret = lttng_write(fd, &hdr, sizeof(hdr));
+	if (size_ret < sizeof(hdr)) {
+		PERROR("write index header");
+		goto error;
+	}
+
+	index_file->major = idx_major;
+	index_file->minor = idx_minor;
+	index_file->element_len = ctf_packet_index_len(idx_major, idx_minor);
+	urcu_ref_init(&index_file->ref);
+
+	fs_handle_put_fd(fs_handle);
+
+	return index_file;
+
+error:
+	if (fd >= 0) {
+		fs_handle_put_fd(fs_handle);
+	}
+	if (fs_handle) {
+		int close_ret;
+
+		close_ret = fs_handle_close(fs_handle);
+		if (close_ret < 0) {
+			PERROR("Failed to close index filesystem handle");
+		}
+	}
+	free(index_file);
+	return NULL;
+}
+
+static
+int open_file(void *data, int *out_fd)
+{
+	int ret;
+	const char *path = data;
+
+	ret = open(path, O_RDONLY);
+	if (ret < 0) {
+		goto end;
+	}
+	*out_fd = ret;
+	ret = 0;
+end:
+	return ret;
+}
+
+struct relay_index_file *relay_index_file_open(const char *path_name,
+		const char *channel_name, uint64_t tracefile_count,
+		uint64_t tracefile_count_current)
+{
+	struct relay_index_file *index_file;
+	int ret, fd;
+	ssize_t read_len;
+	char fullpath[PATH_MAX];
+	char *path_param = fullpath;
+	struct ctf_packet_index_file_hdr hdr;
+	uint32_t major, minor, element_len;
+
+	assert(path_name);
+	assert(channel_name);
+
+	index_file = zmalloc(sizeof(*index_file));
+	if (!index_file) {
+		PERROR("Failed to allocate relay_index_file");
+		goto error;
+	}
+
+	index_file->suspendable = false;
+
+	if (tracefile_count > 0) {
+		ret = snprintf(fullpath, sizeof(fullpath), "%s/" DEFAULT_INDEX_DIR "/%s_%"
+				PRIu64 DEFAULT_INDEX_FILE_SUFFIX, path_name,
+				channel_name, tracefile_count_current);
+	} else {
+		ret = snprintf(fullpath, sizeof(fullpath), "%s/" DEFAULT_INDEX_DIR "/%s"
+				DEFAULT_INDEX_FILE_SUFFIX, path_name, channel_name);
+	}
+	if (ret < 0) {
+		PERROR("Failed to build index path");
+		goto error;
+	}
+
+	DBG("Index opening file %s in read only", fullpath);
+	ret = fd_tracker_open_unsuspendable_fd(the_fd_tracker, &fd,
+			(const char **) &path_param, 1,
+			open_file, (void *) fullpath);
+	if (ret < 0) {
+		PERROR("Failed to open index file at %s", fullpath);
+		goto error;
+	}
+
+	read_len = lttng_read(fd, &hdr, sizeof(hdr));
+	if (read_len < 0) {
+		PERROR("Failed to read index header");
+		goto error_close;
+	}
+
+	if (be32toh(hdr.magic) != CTF_INDEX_MAGIC) {
+		ERR("Invalid header magic %#010x, expected %#010x",
+				be32toh(hdr.magic), CTF_INDEX_MAGIC);
+		goto error_close;
+	}
+	major = be32toh(hdr.index_major);
+	minor = be32toh(hdr.index_minor);
+	element_len = be32toh(hdr.packet_index_len);
+
+	if (major != CTF_INDEX_MAJOR) {
+		ERR("Invalid header version, major = %" PRIu32 ", expected %i",
+				major, CTF_INDEX_MAJOR);
+		goto error_close;
+	}
+	if (element_len > sizeof(struct ctf_packet_index)) {
+		ERR("Index element length too long (%" PRIu32 " bytes)",
+				element_len);
+		goto error_close;
+	}
+
+	index_file->u.fd = fd;
+	index_file->major = major;
+	index_file->minor = minor;
+	index_file->element_len = element_len;
+	urcu_ref_init(&index_file->ref);
+
+	return index_file;
+
+error_close:
+	ret = fd_tracker_close_unsuspendable_fd(the_fd_tracker, &fd,
+			1, fd_tracker_util_close_fd, NULL);
+	if (ret < 0) {
+		PERROR("Failed to close index fd %d", fd);
+	}
+
+error:
+	free(index_file);
+	return NULL;
+}
+
+int relay_index_file_write(const struct relay_index_file *index_file,
+		const struct ctf_packet_index *element)
+{
+	int fd, ret;
+	ssize_t write_ret;
+
+	assert(index_file);
+	assert(element);
+
+	fd = index_file->suspendable ?
+			fs_handle_get_fd(index_file->u.handle) :
+			index_file->u.fd;
+	if (fd < 0) {
+		ret = fd;
+		goto end;
+	}
+
+	write_ret = lttng_write(fd, element, index_file->element_len);
+	if (write_ret < index_file->element_len) {
+		PERROR("Failed to write packet index to index file");
+		ret = -1;
+	}
+	ret = 0;
+
+	if (index_file->suspendable) {
+		fs_handle_put_fd(index_file->u.handle);
+	}
+end:
+	return ret;
+}
+
+int relay_index_file_read(const struct relay_index_file *index_file,
+		struct ctf_packet_index *element)
+{
+	int fd, ret;
+	ssize_t read_ret;
+
+	assert(index_file);
+	assert(element);
+
+	fd = index_file->suspendable ?
+			fs_handle_get_fd(index_file->u.handle) :
+			index_file->u.fd;
+	if (fd < 0) {
+		ret = fd;
+		goto end;
+	}
+
+	read_ret = lttng_read(fd, element, index_file->element_len);
+	if (read_ret < index_file->element_len) {
+		PERROR("Failed to read packet index from file");
+		ret = -1;
+	}
+	ret = 0;
+
+	if (index_file->suspendable) {
+		fs_handle_put_fd(index_file->u.handle);
+	}
+end:
+	return ret;
+}
+
+int relay_index_file_seek_end(struct relay_index_file *index_file)
+{
+	int fd, ret = 0;
+	off_t lseek_ret;
+
+	fd = index_file->suspendable ?
+			fs_handle_get_fd(index_file->u.handle) :
+			index_file->u.fd;
+	if (fd < 0) {
+		ret = fd;
+		goto end;
+	}
+
+	lseek_ret = lseek(fd, 0, SEEK_END);
+	if (lseek_ret < 0) {
+		ret = lseek_ret;
+	}
+
+	if (index_file->suspendable) {
+		fs_handle_put_fd(index_file->u.handle);
+	}
+end:
+	return ret;
+}
+
+void relay_index_file_get(struct relay_index_file *index_file)
+{
+	urcu_ref_get(&index_file->ref);
+}
+
+static
+void relay_index_file_release(struct urcu_ref *ref)
+{
+	int ret;
+	struct relay_index_file *index_file = caa_container_of(ref,
+			struct relay_index_file, ref);
+
+	if (index_file->suspendable) {
+		ret = fs_handle_close(index_file->u.handle);
+	} else {
+		ret = fd_tracker_close_unsuspendable_fd(the_fd_tracker, &index_file->u.fd,
+				1, fd_tracker_util_close_fd, NULL);
+	}
+	if (ret < 0) {
+		PERROR("Failed to close index file");
+	}
+	free(index_file);
+}
+
+void relay_index_file_put(struct relay_index_file *index_file)
+{
+	urcu_ref_put(&index_file->ref, relay_index_file_release);
+}

--- a/src/bin/lttng-relayd/index-file.h
+++ b/src/bin/lttng-relayd/index-file.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 - Jérémie Galarneau <jeremie.galarneau@efficios.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef RELAY_INDEX_FILE_H
+#define RELAY_INDEX_FILE_H
+
+#include <stdint.h>
+#include <common/index/ctf-index.h>
+
+struct relay_index_file;
+
+/*
+ * create and open have refcount of 1. Use put to decrement the
+ * refcount. Destroys when reaching 0. Use "get" to increment refcount.
+ */
+struct relay_index_file *relay_index_file_create(const char *path_name,
+		const char *stream_name, uint64_t size,
+		uint64_t count, uint32_t major, uint32_t minor);
+struct relay_index_file *relay_index_file_open(const char *path_name,
+		const char *channel_name, uint64_t tracefile_count,
+		uint64_t tracefile_count_current);
+
+int relay_index_file_write(const struct relay_index_file *index_file,
+		const struct ctf_packet_index *element);
+int relay_index_file_read(const struct relay_index_file *index_file,
+		struct ctf_packet_index *element);
+
+int relay_index_file_seek_end(struct relay_index_file *index_file);
+
+void relay_index_file_get(struct relay_index_file *index_file);
+void relay_index_file_put(struct relay_index_file *index_file);
+
+#endif /* RELAY_INDEX_FILE_H */

--- a/src/bin/lttng-relayd/index.h
+++ b/src/bin/lttng-relayd/index.h
@@ -22,10 +22,11 @@
 
 #include <inttypes.h>
 #include <pthread.h>
+#include <urcu/ref.h>
 
 #include <common/hashtable/hashtable.h>
-#include <common/index/index.h>
 
+#include "index-file.h"
 #include "stream-fd.h"
 
 struct relay_stream;
@@ -42,7 +43,7 @@ struct relay_index {
 	 * index file on which to write the index data. May differ from
 	 * stream->index_file due to tracefile rotation.
 	 */
-	struct lttng_index_file *index_file;
+	struct relay_index_file *index_file;
 
 	/* Index packet data. This is the data that is written on disk. */
 	struct ctf_packet_index index_data;
@@ -66,7 +67,7 @@ struct relay_index *relay_index_get_by_id_or_create(struct relay_stream *stream,
 		uint64_t net_seq_num);
 void relay_index_put(struct relay_index *index);
 int relay_index_set_file(struct relay_index *index,
-		struct lttng_index_file *index_file,
+		struct relay_index_file *index_file,
 		uint64_t data_offset);
 int relay_index_set_data(struct relay_index *index,
                 const struct ctf_packet_index *data);

--- a/src/bin/lttng-relayd/live.c
+++ b/src/bin/lttng-relayd/live.c
@@ -433,14 +433,40 @@ int check_thread_quit_pipe(int fd, uint32_t events)
 	return 0;
 }
 
+static
+int create_sock(void *data, int *out_fd)
+{
+	int ret;
+	struct lttcomm_sock *sock = data;
+
+	ret = lttcomm_create_sock(sock);
+	if (ret < 0) {
+		goto end;
+	}
+
+	*out_fd = sock->fd;
+end:
+	return ret;
+}
+
+static
+int close_sock(void *data, int *in_fd)
+{
+	struct lttcomm_sock *sock = data;
+
+	return sock->ops->close(sock);
+}
+
 /*
  * Create and init socket from uri.
  */
 static
-struct lttcomm_sock *init_socket(struct lttng_uri *uri)
+struct lttcomm_sock *init_socket(struct lttng_uri *uri, const char *name)
 {
-	int ret;
+	int ret, sock_fd;
 	struct lttcomm_sock *sock = NULL;
+	char uri_str[PATH_MAX];
+	char *formated_name = NULL;
 
 	sock = lttcomm_alloc_sock_from_uri(uri);
 	if (sock == NULL) {
@@ -448,11 +474,25 @@ struct lttcomm_sock *init_socket(struct lttng_uri *uri)
 		goto error;
 	}
 
-	ret = lttcomm_create_sock(sock);
-	if (ret < 0) {
-		goto error;
+	/*
+	 * Don't fail to create the socket if the name can't be built as it is
+	 * only used for debugging purposes.
+	 */
+	ret = uri_to_str_url(uri, uri_str, sizeof(uri_str));
+	uri_str[sizeof(uri_str) - 1] = '\0';
+	if (ret >= 0) {
+		ret = asprintf(&formated_name, "%s socket @ %s", name,
+				uri_str);
+		if (ret < 0) {
+			formated_name = NULL;
+		}
 	}
-	DBG("Listening on sock %d for lttng-live", sock->fd);
+
+	ret = fd_tracker_open_unsuspendable_fd(the_fd_tracker, &sock_fd,
+			(const char **) (formated_name ? &formated_name : NULL),
+			1, create_sock, sock);
+	free(formated_name);
+	DBG("Listening on %s socket %d", name, sock->fd);
 
 	ret = sock->ops->bind(sock);
 	if (ret < 0) {
@@ -492,7 +532,7 @@ void *thread_listener(void *data)
 
 	health_code_update();
 
-	live_control_sock = init_socket(live_uri);
+	live_control_sock = init_socket(live_uri, "Live listener");
 	if (!live_control_sock) {
 		goto error_sock_control;
 	}
@@ -616,7 +656,9 @@ error_testpoint:
 	(void) fd_tracker_util_poll_clean(the_fd_tracker, &events);
 error_create_poll:
 	if (live_control_sock->fd >= 0) {
-		ret = live_control_sock->ops->close(live_control_sock);
+		ret = fd_tracker_close_unsuspendable_fd(the_fd_tracker,
+				&live_control_sock->fd, 1, close_sock,
+				live_control_sock);
 		if (ret) {
 			PERROR("close");
 		}

--- a/src/bin/lttng-relayd/live.c
+++ b/src/bin/lttng-relayd/live.c
@@ -393,7 +393,8 @@ int relayd_live_stop(void)
  * Create a poll set with O_CLOEXEC and add the thread quit pipe to the set.
  */
 static
-int create_thread_poll_set(struct lttng_poll_event *events, int size)
+int create_named_thread_poll_set(struct lttng_poll_event *events,
+		int size, const char *name)
 {
 	int ret;
 
@@ -402,10 +403,8 @@ int create_thread_poll_set(struct lttng_poll_event *events, int size)
 		goto error;
 	}
 
-	ret = lttng_poll_create(events, size, LTTNG_CLOEXEC);
-	if (ret < 0) {
-		goto error;
-	}
+	ret = fd_tracker_util_poll_create(the_fd_tracker,
+		        name, events, 1, LTTNG_CLOEXEC);
 
 	/* Add quit pipe */
 	ret = lttng_poll_add(events, thread_quit_pipe[0], LPOLLIN | LPOLLERR);
@@ -417,6 +416,15 @@ int create_thread_poll_set(struct lttng_poll_event *events, int size)
 
 error:
 	return ret;
+}
+
+/*
+ * Create a poll set with O_CLOEXEC and add the thread quit pipe to the set.
+ */
+static
+int create_thread_poll_set(struct lttng_poll_event *events, int size)
+{
+	return create_named_thread_poll_set(events, size, "Unknown epoll");
 }
 
 /*
@@ -499,7 +507,8 @@ void *thread_listener(void *data)
 	}
 
 	/* Pass 2 as size here for the thread quit pipe and control sockets. */
-	ret = create_thread_poll_set(&events, 2);
+	ret = create_named_thread_poll_set(&events, 2,
+			"Live listener thread epoll");
 	if (ret < 0) {
 		goto error_create_poll;
 	}
@@ -613,7 +622,7 @@ exit:
 error:
 error_poll_add:
 error_testpoint:
-	lttng_poll_clean(&events);
+	(void) fd_tracker_util_poll_clean(the_fd_tracker, &events);
 error_create_poll:
 	if (live_control_sock->fd >= 0) {
 		ret = live_control_sock->ops->close(live_control_sock);

--- a/src/bin/lttng-relayd/live.c
+++ b/src/bin/lttng-relayd/live.c
@@ -53,6 +53,7 @@
 #include <common/sessiond-comm/relayd.h>
 #include <common/uri.h>
 #include <common/utils.h>
+#include <common/fd-tracker/utils.h>
 
 #include "cmd.h"
 #include "live.h"
@@ -2088,7 +2089,7 @@ error_poll_create:
 	lttng_ht_destroy(viewer_connections_ht);
 viewer_connections_ht_error:
 	/* Close relay conn pipes */
-	utils_close_pipe(live_conn_pipe);
+	(void) fd_tracker_util_pipe_close(the_fd_tracker, live_conn_pipe);
 	if (err) {
 		DBG("Viewer worker thread exited with error");
 	}
@@ -2112,7 +2113,8 @@ error_testpoint:
  */
 static int create_conn_pipe(void)
 {
-	return utils_create_pipe_cloexec(live_conn_pipe);
+	return fd_tracker_util_pipe_open_cloexec(the_fd_tracker,
+			"Live connection pipe", live_conn_pipe);
 }
 
 int relayd_live_join(void)

--- a/src/bin/lttng-relayd/live.c
+++ b/src/bin/lttng-relayd/live.c
@@ -419,15 +419,6 @@ error:
 }
 
 /*
- * Create a poll set with O_CLOEXEC and add the thread quit pipe to the set.
- */
-static
-int create_thread_poll_set(struct lttng_poll_event *events, int size)
-{
-	return create_named_thread_poll_set(events, size, "Unknown epoll");
-}
-
-/*
  * Check if the thread quit pipe was triggered.
  *
  * Return 1 if it was triggered else 0;
@@ -1960,7 +1951,8 @@ void *thread_worker(void *data)
 		goto viewer_connections_ht_error;
 	}
 
-	ret = create_thread_poll_set(&events, 2);
+	ret = create_named_thread_poll_set(&events, 2,
+			"Live viewer worker thread epoll");
 	if (ret < 0) {
 		goto error_poll_create;
 	}
@@ -2083,7 +2075,7 @@ restart:
 
 exit:
 error:
-	lttng_poll_clean(&events);
+	(void) fd_tracker_util_poll_clean(the_fd_tracker, &events);
 
 	/* Cleanup remaining connection object. */
 	rcu_read_lock();

--- a/src/bin/lttng-relayd/live.c
+++ b/src/bin/lttng-relayd/live.c
@@ -47,7 +47,6 @@
 #include <common/compat/endian.h>
 #include <common/defaults.h>
 #include <common/futex.h>
-#include <common/index/index.h>
 #include <common/sessiond-comm/sessiond-comm.h>
 #include <common/sessiond-comm/inet.h>
 #include <common/sessiond-comm/relayd.h>
@@ -67,6 +66,7 @@
 #include "ctf-trace.h"
 #include "connection.h"
 #include "viewer-session.h"
+#include "index-file.h"
 
 #define SESSION_BUF_DEFAULT_COUNT	16
 
@@ -1232,7 +1232,7 @@ static int try_open_index(struct relay_viewer_stream *vstream,
 		ret = -ENOENT;
 		goto end;
 	}
-	vstream->index_file = lttng_index_file_open(vstream->path_name,
+	vstream->index_file = relay_index_file_open(vstream->path_name,
 			vstream->channel_name,
 			vstream->stream->tracefile_count,
 			vstream->current_tracefile_id);
@@ -1477,10 +1477,9 @@ int viewer_get_next_index(struct relay_connection *conn)
 		viewer_index.flags |= LTTNG_VIEWER_FLAG_NEW_STREAM;
 	}
 
-	ret = lttng_index_file_read(vstream->index_file, &packet_index);
+	ret = relay_index_file_read(vstream->index_file, &packet_index);
 	if (ret) {
-		ERR("Relay error reading index file %d",
-				vstream->index_file->fd);
+		ERR("Relay error reading index file");
 		viewer_index.status = htobe32(LTTNG_VIEWER_INDEX_ERR);
 		goto send_reply;
 	} else {

--- a/src/bin/lttng-relayd/live.c
+++ b/src/bin/lttng-relayd/live.c
@@ -457,6 +457,44 @@ int close_sock(void *data, int *in_fd)
 	return sock->ops->close(sock);
 }
 
+static int accept_sock(void *data, int *out_fd)
+{
+	int ret = 0;
+	/* Socks is an array of in_sock, out_sock. */
+	struct lttcomm_sock **socks = data;
+	struct lttcomm_sock *in_sock = socks[0];
+
+        socks[1] = in_sock->ops->accept(in_sock);
+	if (!socks[1]) {
+		ret = -1;
+		goto end;
+	}
+	*out_fd = socks[1]->fd;
+end:
+	return ret;
+}
+
+static
+struct lttcomm_sock *accept_live_sock(struct lttcomm_sock *listening_sock,
+		const char *name)
+{
+	int out_fd, ret;
+	struct lttcomm_sock *socks[2] = { listening_sock, NULL };
+	struct lttcomm_sock *new_sock = NULL;
+
+        ret = fd_tracker_open_unsuspendable_fd(
+			the_fd_tracker, &out_fd,
+			(const char **) &name,
+			1, accept_sock, &socks);
+	if (ret) {
+		goto end;
+	}
+	new_sock = socks[1];
+	DBG("%s accepted, socket %d", name, new_sock->fd);
+end:
+	return new_sock;
+}
+
 /*
  * Create and init socket from uri.
  */
@@ -607,7 +645,8 @@ restart:
 				struct relay_connection *new_conn;
 				struct lttcomm_sock *newsock;
 
-				newsock = live_control_sock->ops->accept(live_control_sock);
+				newsock = accept_live_sock(live_control_sock,
+							"Live socket to client");
 				if (!newsock) {
 					PERROR("accepting control sock");
 					goto error;
@@ -1957,7 +1996,8 @@ void cleanup_connection_pollfd(struct lttng_poll_event *events, int pollfd)
 
 	(void) lttng_poll_del(events, pollfd);
 
-	ret = close(pollfd);
+	ret = fd_tracker_close_unsuspendable_fd(the_fd_tracker, &pollfd, 1,
+			fd_tracker_util_close_fd, NULL);
 	if (ret < 0) {
 		ERR("Closing pollfd %d", pollfd);
 	}

--- a/src/bin/lttng-relayd/lttng-relayd.h
+++ b/src/bin/lttng-relayd/lttng-relayd.h
@@ -25,6 +25,7 @@
 #include <urcu/wfcqueue.h>
 
 #include <common/hashtable/hashtable.h>
+#include <common/fd-tracker/fd-tracker.h>
 
 /*
  * Queue used to enqueue relay requests
@@ -49,6 +50,8 @@ extern const char *tracing_group_name;
 extern const char * const config_section_name;
 
 extern int thread_quit_pipe[2];
+
+extern struct fd_tracker *the_fd_tracker;
 
 void lttng_relay_notify_ready(void);
 int lttng_relay_stop_threads(void);

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -784,13 +784,38 @@ static int check_thread_quit_pipe(int fd, uint32_t events)
 	return 0;
 }
 
+static int create_sock(void *data, int *out_fd)
+{
+	int ret;
+	struct lttcomm_sock *sock = data;
+
+	ret = lttcomm_create_sock(sock);
+	if (ret < 0) {
+		goto end;
+	}
+
+	*out_fd = sock->fd;
+end:
+	return ret;
+}
+
+static int close_sock(void *data, int *in_fd)
+{
+	struct lttcomm_sock *sock = data;
+
+	return sock->ops->close(sock);
+}
+
 /*
  * Create and init socket from uri.
  */
-static struct lttcomm_sock *relay_socket_create(struct lttng_uri *uri)
+static struct lttcomm_sock *relay_socket_create(struct lttng_uri *uri,
+		const char *name)
 {
-	int ret;
+	int ret, sock_fd;
 	struct lttcomm_sock *sock = NULL;
+	char uri_str[PATH_MAX];
+	char *formated_name = NULL;
 
 	sock = lttcomm_alloc_sock_from_uri(uri);
 	if (sock == NULL) {
@@ -798,11 +823,25 @@ static struct lttcomm_sock *relay_socket_create(struct lttng_uri *uri)
 		goto error;
 	}
 
-	ret = lttcomm_create_sock(sock);
-	if (ret < 0) {
-		goto error;
+	/*
+	 * Don't fail to create the socket if the name can't be built as it is
+	 * only used for debugging purposes.
+	 */
+	ret = uri_to_str_url(uri, uri_str, sizeof(uri_str));
+	uri_str[sizeof(uri_str) - 1] = '\0';
+	if (ret >= 0) {
+		ret = asprintf(&formated_name, "%s socket @ %s", name,
+				uri_str);
+		if (ret < 0) {
+			formated_name = NULL;
+		}
 	}
-	DBG("Listening on sock %d", sock->fd);
+
+	ret = fd_tracker_open_unsuspendable_fd(the_fd_tracker, &sock_fd,
+			(const char **) (formated_name ? &formated_name : NULL),
+			1, create_sock, sock);
+	free(formated_name);
+	DBG("Listening on %s socket %d", name, sock->fd);
 
 	ret = sock->ops->bind(sock);
 	if (ret < 0) {
@@ -841,7 +880,7 @@ static void *relay_thread_listener(void *data)
 
 	health_code_update();
 
-	control_sock = relay_socket_create(control_uri);
+	control_sock = relay_socket_create(control_uri, "Control listener");
 	if (!control_sock) {
 		goto error_sock_control;
 	}
@@ -1008,7 +1047,9 @@ error_create_poll:
 	lttcomm_destroy_sock(data_sock);
 error_sock_relay:
 	if (control_sock->fd >= 0) {
-		ret = control_sock->ops->close(control_sock);
+		ret = fd_tracker_close_unsuspendable_fd(the_fd_tracker,
+				&control_sock->fd, 1, close_sock,
+				control_sock);
 		if (ret) {
 			PERROR("close");
 		}

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -564,7 +564,7 @@ static void relayd_cleanup(void)
 	free(opt_output_path);
 
 	/* Close thread quit pipes */
-	utils_close_pipe(thread_quit_pipe);
+	(void) fd_tracker_util_pipe_close(the_fd_tracker, thread_quit_pipe);
 
 	uri_free(control_uri);
 	uri_free(data_uri);
@@ -727,11 +727,8 @@ void lttng_relay_notify_ready(void)
  */
 static int init_thread_quit_pipe(void)
 {
-	int ret;
-
-	ret = utils_create_pipe_cloexec(thread_quit_pipe);
-
-	return ret;
+	return fd_tracker_util_pipe_open_cloexec(the_fd_tracker,
+			"Quit pipe", thread_quit_pipe);
 }
 
 /*

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -409,13 +409,14 @@ static int set_fd_pool_size(void)
 		goto end;
 	}
 
-	DBG("File descriptor count limits are %lu (soft) and %lu (hard)",
-			rlimit.rlim_cur, rlimit.rlim_max);
+	DBG("File descriptor count limits are %" PRIu64 " (soft) and %" PRIu64 " (hard)",
+			(uint64_t) rlimit.rlim_cur, (uint64_t) rlimit.rlim_max);
 	if (lttng_opt_fd_pool_size == -1) {
 		/* Use default value (soft limit - reserve). */
 		if (rlimit.rlim_cur < DEFAULT_RELAYD_MIN_FD_POOL_SIZE) {
-			ERR("The process' file number limit is too low (%lu). The process' file number limit must be set to at least %i.",
-					rlimit.rlim_cur, DEFAULT_RELAYD_MIN_FD_POOL_SIZE);
+			ERR("The process' file number limit is too low (%" PRIu64 "). The process' file number limit must be set to at least %i.",
+					(uint64_t) rlimit.rlim_cur,
+					DEFAULT_RELAYD_MIN_FD_POOL_SIZE);
 			ret = -1;
 			goto end;
 		}

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -1018,9 +1018,8 @@ restart:
 				} else {
 					assert(pollfd == control_sock->fd);
 					type = RELAY_CONTROL;
-					newsock = control_sock->ops->accept(control_sock);
-					DBG("Relay control connection accepted, socket %d",
-							newsock->fd);
+					newsock = accept_relayd_sock(control_sock,
+							"Control socket to relayd");
 				}
 				if (!newsock) {
 					PERROR("accepting sock");

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -772,14 +772,6 @@ error:
 }
 
 /*
- * Create a poll set with O_CLOEXEC and add the thread quit pipe to the set.
- */
-static int create_thread_poll_set(struct lttng_poll_event *events, int size)
-{
-	return create_named_thread_poll_set(events, size, "Unknown epoll");
-}
-
-/*
  * Check if the thread quit pipe was triggered.
  *
  * Return 1 if it was triggered else 0;
@@ -864,7 +856,7 @@ static void *relay_thread_listener(void *data)
 	 * Pass 3 as size here for the thread quit pipe, control and
 	 * data socket.
 	 */
-	ret = create_thread_poll_set(&events, 3);
+	ret = create_named_thread_poll_set(&events, 3, "Listener thread epoll");
 	if (ret < 0) {
 		goto error_create_poll;
 	}
@@ -1006,7 +998,7 @@ exit:
 error:
 error_poll_add:
 error_testpoint:
-	lttng_poll_clean(&events);
+	(void) fd_tracker_util_poll_clean(the_fd_tracker, &events);
 error_create_poll:
 	if (data_sock->fd >= 0) {
 		ret = data_sock->ops->close(data_sock);

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -885,7 +885,7 @@ static void *relay_thread_listener(void *data)
 		goto error_sock_control;
 	}
 
-	data_sock = relay_socket_create(data_uri);
+	data_sock = relay_socket_create(data_uri, "Data listener");
 	if (!data_sock) {
 		goto error_sock_relay;
 	}
@@ -1039,7 +1039,9 @@ error_testpoint:
 	(void) fd_tracker_util_poll_clean(the_fd_tracker, &events);
 error_create_poll:
 	if (data_sock->fd >= 0) {
-		ret = data_sock->ops->close(data_sock);
+		ret = fd_tracker_close_unsuspendable_fd(the_fd_tracker,
+				&data_sock->fd, 1, close_sock,
+				data_sock);
 		if (ret) {
 			PERROR("close");
 		}

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -34,11 +34,13 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <sys/resource.h>
 #include <inttypes.h>
 #include <urcu/futex.h>
 #include <urcu/uatomic.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <ctype.h>
 
 #include <lttng/lttng.h>
 #include <common/common.h>
@@ -155,6 +157,9 @@ static uint64_t last_relay_stream_id;
  */
 static struct relay_conn_queue relay_conn_queue;
 
+/* Cap of file desriptors to be in simultaneous use by the relay daemon. */
+static unsigned int lttng_opt_fd_cap;
+
 /* Global relay stream hash table. */
 struct lttng_ht *relay_streams_ht;
 
@@ -174,6 +179,7 @@ static struct option long_options[] = {
 	{ "daemonize", 0, 0, 'd', },
 	{ "background", 0, 0, 'b', },
 	{ "group", 1, 0, 'g', },
+	{ "fd-cap", 1, 0, '\0', },
 	{ "help", 0, 0, 'h', },
 	{ "output", 1, 0, 'o', },
 	{ "verbose", 0, 0, 'v', },
@@ -196,9 +202,33 @@ static int set_option(int opt, const char *arg, const char *optname)
 
 	switch (opt) {
 	case 0:
-		fprintf(stderr, "option %s", optname);
-		if (arg) {
-			fprintf(stderr, " with arg %s\n", arg);
+		if (!strcmp(optname, "fd-cap")) {
+			unsigned long v;
+
+			errno = 0;
+			v = strtoul(arg, NULL, 0);
+			if (errno != 0 || !isdigit(arg[0])) {
+				ERR("Wrong value in --fd-cap parameter: %s", arg);
+				ret = -1;
+				goto end;
+			}
+			if (v < DEFAULT_RELAYD_MINIMAL_FD_CAP) {
+				ERR("File descriptor cap must be set to at least %d",
+						DEFAULT_RELAYD_MINIMAL_FD_CAP);
+			}
+			if (v >= UINT_MAX) {
+				ERR("File descriptor cap overflow in --fd-cap parameter: %s", arg);
+				ret = -1;
+				goto end;
+			}
+			lttng_opt_fd_cap = (unsigned int) v;
+			DBG3("File descriptor cap set to %u", lttng_opt_fd_cap);
+
+		} else {
+			fprintf(stderr, "unknown option %s", optname);
+			if (arg) {
+				fprintf(stderr, " with arg %s\n", arg);
+			}
 		}
 		break;
 	case 'C':
@@ -485,6 +515,18 @@ static int set_options(int argc, char **argv)
 			retval = -1;
 			goto exit;
 		}
+	}
+	if (lttng_opt_fd_cap == 0) {
+		int ret;
+		struct rlimit rlimit;
+
+		ret = getrlimit(RLIMIT_NOFILE, &rlimit);
+		if (ret) {
+			PERROR("Failed to get file descriptor limit");
+			retval = -1;
+		}
+
+		lttng_opt_fd_cap = rlimit.rlim_cur;
 	}
 
 exit:

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -3916,7 +3916,8 @@ error_poll_create:
 	lttng_ht_destroy(relay_connections_ht);
 relay_connections_ht_error:
 	/* Close relay conn pipes */
-	utils_close_pipe(relay_conn_pipe);
+	(void) fd_tracker_util_pipe_close(the_fd_tracker,
+			relay_conn_pipe);
 	if (err) {
 		DBG("Thread exited with error");
 	}
@@ -3938,11 +3939,8 @@ error_testpoint:
  */
 static int create_relay_conn_pipe(void)
 {
-	int ret;
-
-	ret = utils_create_pipe_cloexec(relay_conn_pipe);
-
-	return ret;
+	return fd_tracker_util_pipe_open_cloexec(the_fd_tracker,
+			"Relayd connection pipe", relay_conn_pipe);
 }
 
 /*

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -3968,6 +3968,11 @@ int main(int argc, char **argv)
 		goto exit_options;
 	}
 
+	ret = fclose(stdin);
+	if (ret) {
+		PERROR("Failed to close stdin");
+		goto exit_options;
+	}
 	/* Try to create directory if -o, --output is specified. */
 	if (opt_output_path) {
 		if (*opt_output_path != '/') {

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -1668,14 +1668,14 @@ int create_rotate_index_file(struct relay_stream *stream)
 
 	/* Put ref on previous index_file. */
 	if (stream->index_file) {
-		lttng_index_file_put(stream->index_file);
+		relay_index_file_put(stream->index_file);
 		stream->index_file = NULL;
 	}
 	major = stream->trace->session->major;
 	minor = stream->trace->session->minor;
-	stream->index_file = lttng_index_file_create(stream->path_name,
+	stream->index_file = relay_index_file_create(stream->path_name,
 			stream->channel_name,
-			-1, -1, stream->tracefile_size,
+			stream->tracefile_size,
 			tracefile_array_get_file_index_head(stream->tfa),
 			lttng_to_index_major(major, minor),
 			lttng_to_index_minor(major, minor));

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -60,6 +60,7 @@
 #include <common/config/session-config.h>
 #include <common/dynamic-buffer.h>
 #include <common/buffer-view.h>
+#include <common/fd-tracker/utils.h>
 #include <urcu/rculist.h>
 
 #include "cmd.h"
@@ -745,7 +746,8 @@ static int init_health_quit_pipe(void)
 /*
  * Create a poll set with O_CLOEXEC and add the thread quit pipe to the set.
  */
-static int create_thread_poll_set(struct lttng_poll_event *events, int size)
+static int create_named_thread_poll_set(struct lttng_poll_event *events,
+		int size, const char *name)
 {
 	int ret;
 
@@ -754,10 +756,8 @@ static int create_thread_poll_set(struct lttng_poll_event *events, int size)
 		goto error;
 	}
 
-	ret = lttng_poll_create(events, size, LTTNG_CLOEXEC);
-	if (ret < 0) {
-		goto error;
-	}
+	ret = fd_tracker_util_poll_create(the_fd_tracker,
+		        name, events, 1, LTTNG_CLOEXEC);
 
 	/* Add quit pipe */
 	ret = lttng_poll_add(events, thread_quit_pipe[0], LPOLLIN | LPOLLERR);
@@ -769,6 +769,14 @@ static int create_thread_poll_set(struct lttng_poll_event *events, int size)
 
 error:
 	return ret;
+}
+
+/*
+ * Create a poll set with O_CLOEXEC and add the thread quit pipe to the set.
+ */
+static int create_thread_poll_set(struct lttng_poll_event *events, int size)
+{
+	return create_named_thread_poll_set(events, size, "Unknown epoll");
 }
 
 /*
@@ -3650,7 +3658,7 @@ static void *relay_thread_worker(void *data)
 		goto relay_connections_ht_error;
 	}
 
-	ret = create_thread_poll_set(&events, 2);
+	ret = create_named_thread_poll_set(&events, 2, "Worker thread epoll");
 	if (ret < 0) {
 		goto error_poll_create;
 	}
@@ -3922,7 +3930,7 @@ error:
 	}
 	rcu_read_unlock();
 
-	lttng_poll_clean(&events);
+	(void) fd_tracker_util_poll_clean(the_fd_tracker, &events);
 error_poll_create:
 	lttng_ht_destroy(relay_connections_ht);
 relay_connections_ht_error:

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -3992,22 +3992,11 @@ int main(int argc, char **argv)
 
 	/* Daemonize */
 	if (opt_daemon || opt_background) {
-		int i;
-
 		ret = lttng_daemonize(&child_ppid, &recv_child_signal,
 			!opt_background);
 		if (ret < 0) {
 			retval = -1;
 			goto exit_options;
-		}
-
-		/*
-		 * We are in the child. Make sure all other file
-		 * descriptors are closed, in case we are called with
-		 * more opened file descriptors than the standard ones.
-		 */
-		for (i = 3; i < sysconf(_SC_OPEN_MAX); i++) {
-			(void) close(i);
 		}
 	}
 

--- a/src/bin/lttng-relayd/main.c
+++ b/src/bin/lttng-relayd/main.c
@@ -732,6 +732,17 @@ static int init_thread_quit_pipe(void)
 }
 
 /*
+ * Init health quit pipe.
+ *
+ * Return -1 on error or 0 if all pipes are created.
+ */
+static int init_health_quit_pipe(void)
+{
+	return fd_tracker_util_pipe_open_cloexec(the_fd_tracker,
+			"Health quit pipe", health_quit_pipe);
+}
+
+/*
  * Create a poll set with O_CLOEXEC and add the thread quit pipe to the set.
  */
 static int create_thread_poll_set(struct lttng_poll_event *events, int size)
@@ -4057,7 +4068,7 @@ int main(int argc, char **argv)
 		goto exit_init_data;
 	}
 
-	ret = utils_create_pipe(health_quit_pipe);
+	ret = init_health_quit_pipe();
 	if (ret) {
 		retval = -1;
 		goto exit_health_quit_pipe;
@@ -4153,7 +4164,7 @@ exit_dispatcher_thread:
 	}
 exit_health_thread:
 
-	utils_close_pipe(health_quit_pipe);
+	(void) fd_tracker_util_pipe_close(the_fd_tracker, health_quit_pipe);
 exit_health_quit_pipe:
 
 exit_init_data:

--- a/src/bin/lttng-relayd/session.c
+++ b/src/bin/lttng-relayd/session.c
@@ -157,7 +157,7 @@ static void destroy_session(struct relay_session *session)
 	call_rcu(&session->rcu_node, rcu_destroy_session);
 }
 
-void session_release(struct urcu_ref *ref)
+static void session_release(struct urcu_ref *ref)
 {
 	struct relay_session *session =
 			caa_container_of(ref, struct relay_session, ref);

--- a/src/bin/lttng-relayd/stream-fd.c
+++ b/src/bin/lttng-relayd/stream-fd.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 - Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+ *               2018 - Jérémie Galarneau <jeremie.galarneau@efficios.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License, version 2 only, as
@@ -16,11 +17,30 @@
  */
 
 #define _LGPL_SOURCE
+
+#include <urcu/ref.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 #include <common/common.h>
+#include <common/fd-tracker/fd-tracker.h>
+#include <common/fd-tracker/utils.h>
+#include <common/utils.h>
 
 #include "stream-fd.h"
+#include "lttng-relayd.h"
 
-struct stream_fd *stream_fd_create(int fd)
+struct stream_fd {
+	bool suspendable;
+	union {
+		/* Suspendable. */
+		struct fs_handle *handle;
+		/* Unsuspendable. */
+		int fd;
+	} u;
+	struct urcu_ref ref;
+};
+
+static struct stream_fd *_stream_fd_alloc(void)
 {
 	struct stream_fd *sf;
 
@@ -29,9 +49,198 @@ struct stream_fd *stream_fd_create(int fd)
 		goto end;
 	}
 	urcu_ref_init(&sf->ref);
-	sf->fd = fd;
 end:
 	return sf;
+}
+
+static struct stream_fd *stream_fd_suspendable_create(struct fs_handle *handle)
+{
+	struct stream_fd *stream_fd = _stream_fd_alloc();
+
+	if (!stream_fd) {
+		goto end;
+	}
+
+	stream_fd->suspendable = true;
+	stream_fd->u.handle = handle;
+end:
+	return stream_fd;
+}
+
+static struct stream_fd *stream_fd_unsuspendable_create(int fd)
+{
+	struct stream_fd *stream_fd = _stream_fd_alloc();
+
+	if (!stream_fd) {
+		goto end;
+	}
+
+	stream_fd->suspendable = false;
+	stream_fd->u.fd = fd;
+end:
+	return stream_fd;
+}
+
+static int open_file(void *data, int *out_fd)
+{
+	int ret;
+	const char *path = data;
+
+	ret = open(path, O_RDONLY);
+	if (ret < 0) {
+		goto end;
+	}
+	*out_fd = ret;
+	ret = 0;
+end:
+	return ret;
+}
+
+/*
+ * Stream files are opened (read-only) on the live end of the relayd.
+ * In live mode, it is expected that a client is able to consume a
+ * complete file even if it is replaced (in file rotation mode).
+ *
+ * Thus, it is not possible to open those files as suspendable file
+ * handles. This means that live clients can keep a large number of
+ * open file descriptors. As a work-around, we could create hard links
+ * to the files to make the files suspendable. The original file would be
+ * replaced, but the viewer's hard-link would ensure that the inode is
+ * still available for restoration.
+ *
+ * The main roadblock to this approach is validating that the trace
+ * directory resides in a filesystem that supports hard-links. Otherwise,
+ * a cooperative mechanism could allow the viewer end to mark a file as
+ * being in use and it could be renamed rather than unlinked by the
+ * receiving end.
+ */
+struct stream_fd *stream_fd_open(const char *path)
+{
+	int ret, fd;
+	struct stream_fd *stream_fd = NULL;
+
+	ret = fd_tracker_open_unsuspendable_fd(the_fd_tracker, &fd,
+			(const char **) &path, 1,
+			open_file, (void *) path);
+	if (ret) {
+		goto end;
+	}
+
+	stream_fd = stream_fd_unsuspendable_create(fd);
+	if (!stream_fd) {
+		(void) fd_tracker_close_unsuspendable_fd(the_fd_tracker, &fd, 1,
+				fd_tracker_util_close_fd, NULL);
+	}
+end:
+	return stream_fd;
+}
+
+static
+struct fs_handle *create_fs_handle(const char *path)
+{
+	struct fs_handle *handle;
+	/*
+	 * With the session rotation feature on the relay, we might need to seek
+	 * and truncate a tracefile, so we need read and write access.
+	 */
+	int flags = O_RDWR | O_CREAT | O_TRUNC;
+	/* Open with 660 mode */
+	mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
+
+	handle =  fd_tracker_open_fs_handle(the_fd_tracker, path, flags, &mode);
+	if (!handle) {
+		ERR("Failed to open fs handle to %s", path);
+	}
+
+	return handle;
+}
+
+/*
+ * Stream file are created by on the consumerd/data-reception end. Those
+ * stream fds can be suspended as there is no expectation that the files
+ * will be unlinked and then need to be appended-to.
+ *
+ * Hence, the file descriptors are created as suspendable to allow the
+ * fd-tracker to reduce the number of active fds..
+ */
+struct stream_fd *stream_fd_create(const char *path_name, const char *file_name,
+		uint64_t size, uint64_t count, const char *suffix)
+{
+	struct stream_fd *stream_fd = NULL;
+	struct fs_handle *handle;
+	int ret;
+	char path[PATH_MAX];
+
+	ret = utils_stream_file_name(path, path_name, file_name,
+			size, count, suffix);
+	if (ret < 0) {
+		goto end;
+	}
+
+	handle = create_fs_handle(path);
+	if (!handle) {
+		goto end;
+	}
+
+	stream_fd = stream_fd_suspendable_create(handle);
+	if (!stream_fd) {
+		(void) fs_handle_close(handle);
+	}
+	
+end:
+	return stream_fd;
+}
+
+int stream_fd_rotate(struct stream_fd *stream_fd, const char *path_name,
+		const char *file_name, uint64_t size,
+		uint64_t count, uint64_t *new_count)
+{
+	int ret;
+	bool should_unlink;
+	char path[PATH_MAX];
+
+	assert(stream_fd);
+	assert(stream_fd->suspendable);
+
+	utils_stream_file_rotation_get_new_count(count, new_count,
+			&should_unlink);
+
+	ret = utils_stream_file_name(path, path_name, file_name,
+			size, count, NULL);
+	if (ret < 0) {
+		goto error;
+	}
+
+	ret = fs_handle_close(stream_fd->u.handle);
+	stream_fd->u.handle = NULL;
+	if (ret < 0) {
+		PERROR("Closing stream tracefile handle");
+		goto error;
+	}
+	
+	if (should_unlink) {
+		unlink(path);
+		if (ret < 0 && errno != ENOENT) {
+			goto error;
+		}
+	}
+
+	ret = utils_stream_file_name(path, path_name, file_name,
+			size, new_count ? *new_count : 0, NULL);
+	if (ret < 0) {
+		goto error;
+	}
+
+	stream_fd->u.handle = create_fs_handle(path);
+	if (!stream_fd->u.handle) {
+		ret = -1;
+		goto error;
+	}
+
+	ret = 0;
+
+error:
+	return ret;
 }
 
 void stream_fd_get(struct stream_fd *sf)
@@ -44,9 +253,14 @@ static void stream_fd_release(struct urcu_ref *ref)
 	struct stream_fd *sf = caa_container_of(ref, struct stream_fd, ref);
 	int ret;
 
-	ret = close(sf->fd);
+	if (sf->suspendable) {
+		ret = fs_handle_close(sf->u.handle);
+	} else {
+		ret = fd_tracker_close_unsuspendable_fd(the_fd_tracker, &sf->u.fd,
+				1, fd_tracker_util_close_fd, NULL);
+	}
 	if (ret) {
-		PERROR("Error closing stream FD %d", sf->fd);
+		PERROR("Error closing stream handle");
 	}
 	free(sf);
 }
@@ -54,4 +268,16 @@ static void stream_fd_release(struct urcu_ref *ref)
 void stream_fd_put(struct stream_fd *sf)
 {
 	urcu_ref_put(&sf->ref, stream_fd_release);
+}
+
+int stream_fd_get_fd(struct stream_fd *sf)
+{
+	return sf->suspendable ? fs_handle_get_fd(sf->u.handle) : sf->u.fd;
+}
+
+void stream_fd_put_fd(struct stream_fd *sf)
+{
+	if (sf->suspendable) {
+		fs_handle_put_fd(sf->u.handle);
+	}
 }

--- a/src/bin/lttng-relayd/stream-fd.h
+++ b/src/bin/lttng-relayd/stream-fd.h
@@ -3,6 +3,7 @@
 
 /*
  * Copyright (C) 2015 - Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+ *               2018 - Jérémie Galarneau <jeremie.galarneau@efficios.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License, version 2 only, as
@@ -18,15 +19,19 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <urcu/ref.h>
+#include <stdint.h>
 
-struct stream_fd {
-	int fd;
-	struct urcu_ref ref;
-};
+struct stream_fd;
 
-struct stream_fd *stream_fd_create(int fd);
+struct stream_fd *stream_fd_open(const char *path);
+struct stream_fd *stream_fd_create(const char *path_name, const char *file_name,
+		uint64_t size, uint64_t count, const char *suffix);
+int stream_fd_rotate(struct stream_fd *sf, const char *path_name,
+		const char *file_name, uint64_t size,
+		uint64_t count, uint64_t *new_count);
 void stream_fd_get(struct stream_fd *sf);
 void stream_fd_put(struct stream_fd *sf);
+int stream_fd_get_fd(struct stream_fd *sf);
+void stream_fd_put_fd(struct stream_fd *sf);
 
 #endif /* _STREAM_FD_H */

--- a/src/bin/lttng-relayd/stream.c
+++ b/src/bin/lttng-relayd/stream.c
@@ -115,13 +115,8 @@ struct relay_stream *stream_create(struct ctf_trace *trace,
 	 * No need to use run_as API here because whatever we receive,
 	 * the relayd uses its own credentials for the stream files.
 	 */
-	ret = utils_create_stream_file(stream->path_name, stream->channel_name,
-			stream->tracefile_size, 0, -1, -1, NULL);
-	if (ret < 0) {
-		ERR("Create output file");
-		goto end;
-	}
-	stream->stream_fd = stream_fd_create(ret);
+	stream->stream_fd = stream_fd_create(stream->path_name,
+			stream->channel_name, stream->tracefile_size, 0, NULL);
 	if (!stream->stream_fd) {
 		if (close(ret)) {
 			PERROR("Error closing file %d", ret);

--- a/src/bin/lttng-relayd/stream.c
+++ b/src/bin/lttng-relayd/stream.c
@@ -290,7 +290,7 @@ static void stream_release(struct urcu_ref *ref)
 		stream->stream_fd = NULL;
 	}
 	if (stream->index_file) {
-		lttng_index_file_put(stream->index_file);
+		relay_index_file_put(stream->index_file);
 		stream->index_file = NULL;
 	}
 	if (stream->trace) {

--- a/src/bin/lttng-relayd/stream.h
+++ b/src/bin/lttng-relayd/stream.h
@@ -30,6 +30,7 @@
 #include "session.h"
 #include "stream-fd.h"
 #include "tracefile-array.h"
+#include "index-file.h"
 
 struct relay_stream_chunk_id {
 	bool is_set;
@@ -58,7 +59,7 @@ struct relay_stream {
 	/* FD on which to write the stream data. */
 	struct stream_fd *stream_fd;
 	/* index file on which to write the index data. */
-	struct lttng_index_file *index_file;
+	struct relay_index_file *index_file;
 
 	char *path_name;
 	char *channel_name;

--- a/src/bin/lttng-relayd/viewer-stream.c
+++ b/src/bin/lttng-relayd/viewer-stream.c
@@ -143,9 +143,8 @@ struct relay_viewer_stream *viewer_stream_create(struct relay_stream *stream,
 
 	/* Globally visible after the add unique. */
 	lttng_ht_node_init_u64(&vstream->stream_n, stream->stream_handle);
-	lttng_ht_add_unique_u64(viewer_streams_ht, &vstream->stream_n);
-
 	urcu_ref_init(&vstream->ref);
+	lttng_ht_add_unique_u64(viewer_streams_ht, &vstream->stream_n);
 
 	return vstream;
 

--- a/src/bin/lttng-relayd/viewer-stream.h
+++ b/src/bin/lttng-relayd/viewer-stream.h
@@ -29,6 +29,7 @@
 #include "ctf-trace.h"
 #include "lttng-viewer-abi.h"
 #include "stream.h"
+#include "index-file.h"
 
 struct relay_stream;
 
@@ -52,7 +53,7 @@ struct relay_viewer_stream {
 	/* FD from which to read the stream data. */
 	struct stream_fd *stream_fd;
 	/* index file from which to read the index data. */
-	struct lttng_index_file *index_file;
+	struct relay_index_file *index_file;
 
 	char *path_name;
 	char *channel_name;

--- a/src/bin/lttng-sessiond/notification-thread-events.c
+++ b/src/bin/lttng-sessiond/notification-thread-events.c
@@ -543,7 +543,7 @@ int evaluate_condition_for_client(struct lttng_trigger *trigger,
 
 	/* Find the channel associated with the trigger. */
 	cds_lfht_for_each_entry(state->channel_triggers_ht, &iter,
-			channel_trigger_list , channel_triggers_ht_node) {
+			channel_trigger_list, channel_triggers_ht_node) {
 		struct lttng_trigger_list_element *element;
 
 		cds_list_for_each_entry(element, &channel_trigger_list->list, node) {

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = subdir-objects
 
-SUBDIRS = string-utils
+SUBDIRS = string-utils fd-tracker
 
 # Make sure to always distribute all folders
 # since SUBDIRS is decided at configure time.

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -6,7 +6,7 @@ SUBDIRS = string-utils
 # since SUBDIRS is decided at configure time.
 DIST_SUBDIRS = compat health hashtable kernel-ctl sessiond-comm relayd \
 	  kernel-consumer ust-consumer testpoint index config consumer \
-	  string-utils
+	  string-utils fd-tracker
 
 if BUILD_LIB_COMPAT
 SUBDIRS += compat

--- a/src/common/defaults.h
+++ b/src/common/defaults.h
@@ -93,6 +93,8 @@
 #define DEFAULT_RELAYD_RUNDIR			"%s"
 #define DEFAULT_RELAYD_PATH			DEFAULT_RELAYD_RUNDIR "/relayd"
 
+#define DEFAULT_RELAYD_MINIMAL_FD_CAP		30
+
 /* Default lttng run directory */
 #define DEFAULT_LTTNG_HOME_ENV_VAR              "LTTNG_HOME"
 #define DEFAULT_LTTNG_FALLBACK_HOME_ENV_VAR	"HOME"

--- a/src/common/defaults.h
+++ b/src/common/defaults.h
@@ -93,7 +93,20 @@
 #define DEFAULT_RELAYD_RUNDIR			"%s"
 #define DEFAULT_RELAYD_PATH			DEFAULT_RELAYD_RUNDIR "/relayd"
 
-#define DEFAULT_RELAYD_MINIMAL_FD_CAP		30
+#define DEFAULT_RELAYD_MIN_FD_POOL_SIZE		100
+/*
+ * The file descriptor pool size needs a reserve buffer to accomodate the
+ * indirect use of short-lived file descriptors. For instance, glibc will
+ * create a socket (and thus, use an fd) during calls to gethostname() or
+ * when querying the user's group. Other calls also probably make use of
+ * short-lived FDs.
+ *
+ * The theoritical maximal reserve corresponds to the number of threads as,
+ * in the worst case, they could all be making such calls.
+ *
+ * This value must be less than DEFAULT_RELAYD_MIN_FD_POOL_SIZE.
+ */
+#define DEFAULT_RELAYD_FD_POOL_SIZE_RESERVE	10
 
 /* Default lttng run directory */
 #define DEFAULT_LTTNG_HOME_ENV_VAR              "LTTNG_HOME"

--- a/src/common/fd-tracker/Makefile.am
+++ b/src/common/fd-tracker/Makefile.am
@@ -6,4 +6,7 @@ else
 COMPAT=utils-poll.c
 endif
 
-libfd_tracker_la_SOURCES = fd-tracker.h fd-tracker.c utils.h utils.c $(COMPAT)
+libfd_tracker_la_SOURCES = fd-tracker.h fd-tracker.c \
+                           utils.h utils.c \
+                           inode.h inode.c \
+                           $(COMPAT)

--- a/src/common/fd-tracker/Makefile.am
+++ b/src/common/fd-tracker/Makefile.am
@@ -1,0 +1,3 @@
+noinst_LTLIBRARIES = libfd-tracker.la
+
+libfd_tracker_la_SOURCES = fd-tracker.h fd-tracker.c utils.h utils.c

--- a/src/common/fd-tracker/Makefile.am
+++ b/src/common/fd-tracker/Makefile.am
@@ -1,3 +1,9 @@
 noinst_LTLIBRARIES = libfd-tracker.la
 
-libfd_tracker_la_SOURCES = fd-tracker.h fd-tracker.c utils.h utils.c
+if COMPAT_EPOLL
+COMPAT=utils-epoll.c
+else
+COMPAT=utils-poll.c
+endif
+
+libfd_tracker_la_SOURCES = fd-tracker.h fd-tracker.c utils.h utils.c $(COMPAT)

--- a/src/common/fd-tracker/fd-tracker.c
+++ b/src/common/fd-tracker/fd-tracker.c
@@ -365,6 +365,8 @@ struct fd_tracker *fd_tracker_create(unsigned int capacity)
 	tracker->capacity = capacity;
 	tracker->unsuspendable_fds = cds_lfht_new(DEFAULT_HT_SIZE, 1, 0,
 			CDS_LFHT_AUTO_RESIZE | CDS_LFHT_ACCOUNTING, NULL);
+	DBG("File descriptor tracker created with a limit of %u simultaneously-opened FDs",
+			capacity);
 end:
 	return tracker;
 }

--- a/src/common/fd-tracker/fd-tracker.c
+++ b/src/common/fd-tracker/fd-tracker.c
@@ -797,6 +797,7 @@ int fs_handle_close(struct fs_handle *handle)
 	pthread_mutex_lock(&handle->lock);
 	fd_tracker_untrack(handle->tracker, handle);
 	if (handle->fd >= 0) {
+		assert(!handle->in_use);
 		/*
 		 * The return value of close() is not propagated as there
 		 * isn't much the user can do about it.

--- a/src/common/fd-tracker/fd-tracker.c
+++ b/src/common/fd-tracker/fd-tracker.c
@@ -510,11 +510,6 @@ struct fs_handle *fd_tracker_open_fs_handle(struct fd_tracker *tracker,
 		goto error_destroy;
 	}
 
-	/*
-	 * Clear the create flag from the open flags as it would make no sense
-	 * to use it when restoring a fs handle.
-	 */
-	properties.flags &= ~O_CREAT;
 	handle->properties = properties;
 	properties.path = NULL;
 

--- a/src/common/fd-tracker/fd-tracker.c
+++ b/src/common/fd-tracker/fd-tracker.c
@@ -15,7 +15,6 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <urcu/ref.h>
 #include <urcu.h>
 #include <urcu/list.h>
 #include <urcu/rculfhash.h>

--- a/src/common/fd-tracker/fd-tracker.c
+++ b/src/common/fd-tracker/fd-tracker.c
@@ -1,0 +1,817 @@
+/*
+ * Copyright (C) 2018 - Jérémie Galarneau <jeremie.galarneau@efficios.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <urcu/ref.h>
+#include <urcu.h>
+#include <urcu/list.h>
+#include <urcu/rculfhash.h>
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include <inttypes.h>
+
+#include "common/macros.h"
+#include "common/error.h"
+#include "common/defaults.h"
+#include "common/hashtable/utils.h"
+#include "common/hashtable/hashtable.h"
+
+#include "fd-tracker.h"
+
+/* Tracker lock must be taken by the user. */
+#define TRACKED_COUNT(tracker)                 \
+	(tracker->count.suspendable.active +   \
+	tracker->count.suspendable.suspended + \
+	tracker->count.unsuspendable)
+
+/* Tracker lock must be taken by the user. */
+#define ACTIVE_COUNT(tracker)                  \
+	(tracker->count.suspendable.active +   \
+	tracker->count.unsuspendable)
+
+/* Tracker lock must be taken by the user. */
+#define SUSPENDED_COUNT(tracker)               \
+	(tracker->count.suspendable.suspended)
+
+/* Tracker lock must be taken by the user. */
+#define SUSPENDABLE_COUNT(tracker)             \
+	(tracker->count.suspendable.active +   \
+	tracker->count.suspendable.suspended)
+
+/* Tracker lock must be taken by the user. */
+#define UNSUSPENDABLE_COUNT(tracker)           \
+	(tracker->count.unsuspendable)
+
+struct fd_tracker {
+	pthread_mutex_t lock;
+	struct {
+	        struct {
+			unsigned int active;
+			unsigned int suspended;
+		} suspendable;
+		unsigned int unsuspendable;
+	} count;
+	unsigned int capacity;
+	struct {
+		uint64_t uses;
+		uint64_t misses;
+		/* Failures to suspend or restore fs handles. */
+		uint64_t errors;
+	} stats;
+	/*
+	 * The head of the active_handles list is always the least recently
+	 * used active handle. When an handle is used, it is removed from the
+	 * list and added to the end. When a file has to be suspended, the
+	 * first element in the list is "popped", suspended, and added to the
+	 * list of suspended handles.
+	 */
+	struct cds_list_head active_handles;
+	struct cds_list_head suspended_handles;
+	struct cds_lfht *unsuspendable_fds;
+};
+
+struct open_properties {
+	char *path;
+	int flags;
+	struct {
+		bool is_set;
+		mode_t value;
+	} mode;
+};
+
+/*
+ * A fs_handle is not ref-counted. Therefore, it is assumed that a
+ * handle is never in-use while it is being reclaimed. It can be
+ * shared by multiple threads, but external synchronization is required
+ * to ensure it is not still being used when it is reclaimed (close method).
+ * In this respect, it is not different from a regular file descriptor.
+ *
+ * The fs_handle lock always nests _within_ the tracker's lock.
+ */
+struct fs_handle {
+	pthread_mutex_t lock;
+	/*
+	 * Weak reference to the tracker. All fs_handles are assumed to have
+	 * been closed at the moment of the destruction of the fd_tracker.
+	 */
+	struct fd_tracker *tracker;
+	struct open_properties properties;
+	int fd;
+	/* inode number of the file at the time of the handle's creation. */
+	uint64_t ino;
+	bool in_use;
+	/* Offset to which the file should be restored. */
+	off_t offset;
+	struct cds_list_head handles_list_node;
+};
+
+struct unsuspendable_fd {
+	/*
+	 * Accesses are only performed through the tracker, which is protected
+	 * by its own lock.
+	 */
+	int fd;
+	char *name;
+	struct cds_lfht_node tracker_node;
+};
+
+static struct {
+	pthread_mutex_t lock;
+	bool initialized;
+	unsigned long value;
+} seed = {
+	.lock = PTHREAD_MUTEX_INITIALIZER,
+};
+
+static int match_fd(struct cds_lfht_node *node, const void *key);
+static void unsuspendable_fd_destroy(struct unsuspendable_fd *entry);
+static struct unsuspendable_fd *unsuspendable_fd_create(const char *name,
+		int fd);
+static int open_from_properties(struct open_properties *properties);
+
+static void fs_handle_log(struct fs_handle *handle);
+static int fs_handle_suspend(struct fs_handle *handle);
+static int fs_handle_restore(struct fs_handle *handle);
+
+static void fd_tracker_track(struct fd_tracker *tracker,
+		struct fs_handle *handle);
+static void fd_tracker_untrack(struct fd_tracker *tracker,
+		struct fs_handle *handle);
+static int fd_tracker_suspend_handles(struct fd_tracker *tracker,
+		unsigned int count);
+static int fd_tracker_restore_handle(struct fd_tracker *tracker,
+		struct fs_handle *handle);
+
+/* Match function of the tracker's unsuspendable_fds hash table. */
+static
+int match_fd(struct cds_lfht_node *node, const void *key)
+{
+	struct unsuspendable_fd *entry =
+		caa_container_of(node, struct unsuspendable_fd, tracker_node);
+
+	return hash_match_key_ulong((void *) (unsigned long) entry->fd,
+			(void *) key);
+}
+
+static
+void unsuspendable_fd_destroy(struct unsuspendable_fd *entry)
+{
+	if (!entry) {
+		return;
+	}
+	free(entry->name);
+	free(entry);
+}
+
+static
+struct unsuspendable_fd *unsuspendable_fd_create(const char *name, int fd)
+{
+	struct unsuspendable_fd *entry =
+			zmalloc(sizeof(*entry));
+
+	if (!entry) {
+		goto error;
+	}
+	if (name) {
+		entry->name = strdup(name);
+		if (!entry->name) {
+			goto error;
+		}
+	}
+	cds_lfht_node_init(&entry->tracker_node);
+	entry->fd = fd;
+	return entry;
+error:
+	unsuspendable_fd_destroy(entry);
+	return NULL;
+}
+
+static
+void fs_handle_log(struct fs_handle *handle)
+{
+	pthread_mutex_lock(&handle->lock);
+	if (handle->fd >= 0) {
+		DBG_NO_LOC("    %s [active, fd %d%s]",
+				handle->properties.path,
+				handle->fd,
+				handle->in_use ? ", in use" : "");
+	} else {
+		DBG_NO_LOC("    %s [suspended]", handle->properties.path);
+	}
+	pthread_mutex_unlock(&handle->lock);
+}
+
+static
+int fs_handle_suspend(struct fs_handle *handle)
+{
+	int ret = 0;
+	struct stat fs_stat;
+
+	pthread_mutex_lock(&handle->lock);
+	assert(handle->fd >= 0);
+	if (handle->in_use) {
+		/* This handle can't be suspended as it is currently in use. */
+		ret = -EAGAIN;
+		goto end;
+	}
+
+	ret = stat(handle->properties.path, &fs_stat);
+	if (ret) {
+	        PERROR("Filesystem handle to %s cannot be suspended as stat() failed",
+				handle->properties.path);
+		ret = -errno;
+		goto end;
+	}
+
+	if (fs_stat.st_ino != handle->ino) {
+		/* Don't suspend as the handle would not be restorable. */
+		WARN("Filesystem handle to %s cannot be suspended as its inode changed",
+				handle->properties.path);
+		ret = -ENOENT;
+		goto end;
+	}
+
+        handle->offset = lseek(handle->fd, 0, SEEK_CUR);
+	if (handle->offset == -1) {
+		WARN("Filesystem handle to %s cannot be suspended as lseek() failed to sample its current position",
+				handle->properties.path);
+		ret = -errno;
+		goto end;
+	}
+
+	ret = close(handle->fd);
+	if (ret) {
+	        PERROR("Filesystem handle to %s cannot be suspended as close() failed",
+				handle->properties.path);
+		ret = -errno;
+		goto end;
+	}
+	DBG("Suspended filesystem handle to %s (fd %i) at position %" PRId64,
+			handle->properties.path, handle->fd, handle->offset);
+	handle->fd = -1;
+end:
+	if (ret) {
+		handle->tracker->stats.errors++;
+	}
+	pthread_mutex_unlock(&handle->lock);
+	return ret;
+}
+
+/* Caller must hold the tracker and handle's locks. */
+static
+int fs_handle_restore(struct fs_handle *handle)
+{
+	int ret, fd = -1;
+
+	assert(handle->fd == -1);
+	ret = open_from_properties(&handle->properties);
+	if (ret < 0) {
+	        PERROR("Failed to restore filesystem handle to %s, open() failed",
+				handle->properties.path);
+		ret = -errno;
+		goto end;
+	}
+	fd = ret;
+
+	ret = lseek(fd, handle->offset, SEEK_SET);
+	if (ret < 0) {
+	        PERROR("Failed to restore filesystem handle to %s, lseek() failed",
+				handle->properties.path);
+		ret = -errno;
+		goto end;
+	}
+	DBG("Restored filesystem handle to %s (fd %i) at position %" PRId64,
+			handle->properties.path, fd, handle->offset);
+	ret = 0;
+	handle->fd = fd;
+	fd = -1;
+end:
+	if (fd >= 0) {
+		(void) close(fd);
+	}
+	return ret;
+}
+
+static
+int open_from_properties(struct open_properties *properties)
+{
+	int ret;
+
+	/*
+	 * open() ignores the 'flags' parameter unless the O_CREAT or O_TMPFILE
+	 * flags are set. O_TMPFILE would not make sense in the context of a
+	 * suspendable fs_handle as it would not be restorable (see OPEN(2)),
+	 * thus it is ignored here.
+	 */
+	if ((properties->flags & O_CREAT) && properties->mode.is_set) {
+		ret = open(properties->path, properties->flags,
+				properties->mode.value);
+	} else {
+		ret = open(properties->path, properties->flags);
+	}
+	/*
+	 * Some flags should not be used beyond the initial open() of a
+	 * restorable file system handle. O_CREAT and O_TRUNC must
+	 * be cleared since it would be unexpected to re-use them
+	 * when the handle is retored:
+	 *  - O_CREAT should not be needed as the file has been created
+	 *    on the initial call to open(),
+	 *  - O_TRUNC would destroy the file's contents by truncating it
+	 *    to length 0.
+	 */
+	properties->flags &= ~(O_CREAT | O_TRUNC);
+	if (ret < 0) {
+		ret = -errno;
+		goto end;
+	}
+end:
+	return ret;
+}
+
+struct fd_tracker *fd_tracker_create(unsigned int capacity)
+{
+	struct fd_tracker *tracker = zmalloc(sizeof(struct fd_tracker));
+
+	if (!tracker) {
+		goto end;
+	}
+
+	pthread_mutex_lock(&seed.lock);
+	if (!seed.initialized) {
+		seed.value = (unsigned long) time(NULL);
+		seed.initialized = true;
+	}
+	pthread_mutex_unlock(&seed.lock);
+
+	CDS_INIT_LIST_HEAD(&tracker->active_handles);
+	CDS_INIT_LIST_HEAD(&tracker->suspended_handles);
+	tracker->capacity = capacity;
+	tracker->unsuspendable_fds = cds_lfht_new(DEFAULT_HT_SIZE, 1, 0,
+			CDS_LFHT_AUTO_RESIZE | CDS_LFHT_ACCOUNTING, NULL);
+end:
+	return tracker;
+}
+
+void fd_tracker_log(struct fd_tracker *tracker)
+{
+	struct fs_handle *handle;
+	struct unsuspendable_fd *unsuspendable_fd;
+	struct cds_lfht_iter iter;
+
+	pthread_mutex_lock(&tracker->lock);
+	DBG_NO_LOC("File descriptor tracker");
+	DBG_NO_LOC("  Stats:");
+	DBG_NO_LOC("    uses:            %" PRIu64, tracker->stats.uses);
+	DBG_NO_LOC("    misses:          %" PRIu64, tracker->stats.misses);
+	DBG_NO_LOC("    errors:          %" PRIu64, tracker->stats.errors);
+	DBG_NO_LOC("  Tracked:           %u", TRACKED_COUNT(tracker));
+	DBG_NO_LOC("    active:          %u", ACTIVE_COUNT(tracker));
+	DBG_NO_LOC("      suspendable:   %u", SUSPENDABLE_COUNT(tracker));
+	DBG_NO_LOC("      unsuspendable: %u", UNSUSPENDABLE_COUNT(tracker));
+	DBG_NO_LOC("    suspended:       %u", SUSPENDED_COUNT(tracker));
+	DBG_NO_LOC("    capacity:        %u", tracker->capacity);
+
+	DBG_NO_LOC("  Tracked suspendable file descriptors");
+	cds_list_for_each_entry(handle, &tracker->active_handles,
+			handles_list_node) {
+		fs_handle_log(handle);
+	}
+	cds_list_for_each_entry(handle, &tracker->suspended_handles,
+			handles_list_node) {
+		fs_handle_log(handle);
+	}
+	if (!SUSPENDABLE_COUNT(tracker)) {
+		DBG_NO_LOC("    None");
+	}
+
+	DBG_NO_LOC("  Tracked unsuspendable file descriptors");
+	rcu_read_lock();
+	cds_lfht_for_each_entry(tracker->unsuspendable_fds, &iter,
+			unsuspendable_fd, tracker_node) {
+		DBG_NO_LOC("    %s [active, fd %d]", unsuspendable_fd->name ? : "Unnamed",
+				unsuspendable_fd->fd);
+	}
+	rcu_read_unlock();
+	if (!UNSUSPENDABLE_COUNT(tracker)) {
+		DBG_NO_LOC("    None");
+	}
+
+	pthread_mutex_unlock(&tracker->lock);
+}
+
+int fd_tracker_destroy(struct fd_tracker *tracker)
+{
+	int ret = 0;
+
+	/*
+	 * Refuse to destroy the tracker as fs_handles may still old
+	 * weak references to the tracker.
+	 */
+	pthread_mutex_lock(&tracker->lock);
+	if (TRACKED_COUNT(tracker)) {
+		ERR("A file descriptor leak has been detected: %u tracked file descriptors are still being tracked",
+				TRACKED_COUNT(tracker));
+		pthread_mutex_unlock(&tracker->lock);
+		fd_tracker_log(tracker);
+		ret = -1;
+		goto end;
+	}
+	pthread_mutex_unlock(&tracker->lock);
+
+	ret = cds_lfht_destroy(tracker->unsuspendable_fds, NULL);
+	assert(!ret);
+	pthread_mutex_destroy(&tracker->lock);
+	free(tracker);
+end:
+	return ret;
+}
+
+struct fs_handle *fd_tracker_open_fs_handle(struct fd_tracker *tracker,
+		const char *path, int flags, mode_t *mode)
+{
+	int ret;
+	struct fs_handle *handle = NULL;
+	struct stat fd_stat;
+	struct open_properties properties = {
+		.path = strdup(path),
+		.flags = flags,
+		.mode.is_set = !!mode,
+		.mode.value = mode ? *mode : 0,
+	};
+
+	if (!properties.path) {
+		goto end;
+	}
+
+	pthread_mutex_lock(&tracker->lock);
+	if (ACTIVE_COUNT(tracker) == tracker->capacity) {
+		if (tracker->count.suspendable.active > 0) {
+			ret = fd_tracker_suspend_handles(tracker, 1);
+			if (ret) {
+				goto error_destroy;
+			}
+		} else {
+			/*
+			 * There are not enough active suspendable file
+			 * descriptors to open a new fd and still accomodate the
+			 * tracker's capacity.
+			 */
+			WARN("Cannot open file system handle, too many unsuspendable file descriptors are opened (%u)",
+					tracker->count.unsuspendable);
+			ret = -EMFILE;
+			goto error_destroy;
+		}
+	}
+
+	handle = zmalloc(sizeof(*handle));
+	if (!handle) {
+		goto end;
+	}
+
+	ret = pthread_mutex_init(&handle->lock, NULL);
+	if (ret) {
+		PERROR("Failed to initialize handle mutex while creating fs handle");
+		free(handle);
+		goto end;
+	}
+
+	handle->fd = open_from_properties(&properties);
+	if (handle->fd < 0) {
+		PERROR("Failed to open fs handle to %s, open() returned", path);
+		ret = -errno;
+		goto error_destroy;
+	}
+
+	/*
+	 * Clear the create flag from the open flags as it would make no sense
+	 * to use it when restoring a fs handle.
+	 */
+	properties.flags &= ~O_CREAT;
+	handle->properties = properties;
+	properties.path = NULL;
+
+	if (fstat(handle->fd, &fd_stat)) {
+		PERROR("Failed to retrieve file descriptor inode while creating fs handle, fstat() returned");
+		ret = -errno;
+		goto error_destroy;
+	}
+	handle->ino = fd_stat.st_ino;
+
+	fd_tracker_track(tracker, handle);
+	handle->tracker = tracker;
+	pthread_mutex_unlock(&tracker->lock);
+end:
+	free(properties.path);
+	return handle;
+error_destroy:
+	pthread_mutex_unlock(&tracker->lock);
+	(void) fs_handle_close(handle);
+	handle = NULL;
+	goto end;
+}
+
+/* Caller must hold the tracker's lock. */
+static
+int fd_tracker_suspend_handles(struct fd_tracker *tracker,
+		unsigned int count)
+{
+	unsigned int left_to_close = count;
+	struct fs_handle *handle, *tmp;
+
+	cds_list_for_each_entry_safe(handle, tmp, &tracker->active_handles,
+			handles_list_node) {
+		int ret;
+
+		fd_tracker_untrack(tracker, handle);
+		ret = fs_handle_suspend(handle);
+		fd_tracker_track(tracker, handle);
+		if (!ret) {
+			left_to_close--;
+		}
+
+		if (!left_to_close) {
+			break;
+		}
+	}
+	return left_to_close ? -EMFILE : 0;
+}
+
+int fd_tracker_open_unsuspendable_fd(struct fd_tracker *tracker,
+		int *out_fds, const char **names, unsigned int fd_count,
+		fd_open_cb open, void *user_data)
+{
+	int ret, user_ret, i, fds_to_suspend;
+	unsigned int active_fds;
+	struct unsuspendable_fd *entries[fd_count];
+
+	memset(entries, 0, sizeof(entries));
+
+	pthread_mutex_lock(&tracker->lock);
+
+	active_fds = ACTIVE_COUNT(tracker);
+	fds_to_suspend = (int) active_fds + (int) fd_count - (int) tracker->capacity;
+	if (fds_to_suspend > 0) {
+		if (fds_to_suspend <= tracker->count.suspendable.active) {
+			ret = fd_tracker_suspend_handles(tracker, fds_to_suspend);
+			if (ret) {
+				goto end;
+			}
+		} else {
+			/*
+			 * There are not enough active suspendable file
+			 * descriptors to open a new fd and still accomodate the
+			 * tracker's capacity.
+			 */
+			WARN("Cannot open unsuspendable fd, too many unsuspendable file descriptors are opened (%u)",
+					tracker->count.unsuspendable);
+			ret = -EMFILE;
+			goto end;
+		}
+	}
+
+	user_ret = open(user_data, out_fds);
+	if (user_ret) {
+		ret = user_ret;
+		goto end;
+	}
+
+	/*
+	 * Add the fds returned by the user's callback to the hashtable
+	 * of unsuspendable fds.
+	 */
+	for (i = 0; i < fd_count; i++) {
+		struct unsuspendable_fd *entry =
+				unsuspendable_fd_create(names ? names[i] : NULL,
+						out_fds[i]);
+
+		if (!entry) {
+			ret = -1;
+			goto end_free_entries;
+		}
+		entries[i] = entry;
+	}
+
+	rcu_read_lock();
+	for (i = 0; i < fd_count; i++) {
+		struct cds_lfht_node *node;
+		struct unsuspendable_fd *entry = entries[i];
+
+		node = cds_lfht_add_unique(
+				tracker->unsuspendable_fds,
+				hash_key_ulong((void *) (unsigned long) out_fds[i],
+						seed.value),
+				match_fd,
+				(void *) (unsigned long) out_fds[i],
+				&entry->tracker_node);
+
+		if (node != &entry->tracker_node) {
+			ret = -EEXIST;
+			rcu_read_unlock();
+			goto end_free_entries;
+		}
+		entries[i] = NULL;
+	}
+	tracker->count.unsuspendable += fd_count;
+	rcu_read_unlock();
+	ret = user_ret;
+end:
+	pthread_mutex_unlock(&tracker->lock);
+	return ret;
+end_free_entries:
+	for (i = 0; i < fd_count; i++) {
+		unsuspendable_fd_destroy(entries[i]);
+	}
+	goto end;
+}
+
+int fd_tracker_close_unsuspendable_fd(struct fd_tracker *tracker,
+		int *fds_in, unsigned int fd_count, fd_close_cb close,
+		void *user_data)
+{
+	int i, ret, user_ret;
+	int fds[fd_count];
+
+	/*
+	 * Maintain a local copy of fds_in as the user's callback may modify its
+	 * contents (e.g. setting the fd(s) to -1 after close).
+	 */
+	memcpy(fds, fds_in, sizeof(*fds) * fd_count);
+
+	pthread_mutex_lock(&tracker->lock);
+	rcu_read_lock();
+
+	/* Let the user close the file descriptors. */
+	user_ret = close(user_data, fds_in);
+	if (user_ret) {
+		ret = user_ret;
+		goto end;
+	}
+
+	/* Untrack the fds that were just closed by the user's callback. */
+	for (i = 0; i < fd_count; i++) {
+		struct cds_lfht_node *node;
+		struct cds_lfht_iter iter;
+		struct unsuspendable_fd *entry;
+
+		cds_lfht_lookup(tracker->unsuspendable_fds,
+				hash_key_ulong((void *) (unsigned long) fds[i],
+						seed.value),
+				match_fd,
+				(void *) (unsigned long) fds[i],
+				&iter);
+		node = cds_lfht_iter_get_node(&iter);
+		if (!node) {
+			/* Unknown file descriptor. */
+			WARN("Untracked file descriptor %d passed to fd_tracker_close_unsuspendable_fd()",
+					fds[i]);
+			ret = -EINVAL;
+			goto end;
+		}
+		entry = caa_container_of(node,
+				struct unsuspendable_fd,
+				tracker_node);
+
+		cds_lfht_del(tracker->unsuspendable_fds, node);
+		unsuspendable_fd_destroy(entry);
+		fds[i] = -1;
+	}
+
+	tracker->count.unsuspendable -= fd_count;
+	ret = 0;
+end:
+	rcu_read_unlock();
+	pthread_mutex_unlock(&tracker->lock);
+	return ret;
+}
+
+/* Caller must have taken the tracker's and handle's locks. */
+static
+void fd_tracker_track(struct fd_tracker *tracker, struct fs_handle *handle)
+{
+	if (handle->fd >= 0) {
+		tracker->count.suspendable.active++;
+		cds_list_add_tail(&handle->handles_list_node,
+				&tracker->active_handles);
+	} else {
+		tracker->count.suspendable.suspended++;
+		cds_list_add_tail(&handle->handles_list_node,
+				&tracker->suspended_handles);
+	}
+}
+
+/* Caller must have taken the tracker's and handle's locks. */
+static
+void fd_tracker_untrack(struct fd_tracker *tracker, struct fs_handle *handle)
+{
+	if (handle->fd >= 0) {
+		tracker->count.suspendable.active--;
+	} else {
+		tracker->count.suspendable.suspended--;
+	}
+	cds_list_del(&handle->handles_list_node);
+}
+
+/* Caller must have taken the tracker's and handle's locks. */
+static
+int fd_tracker_restore_handle(struct fd_tracker *tracker,
+		struct fs_handle *handle)
+{
+	int ret;
+
+	fd_tracker_untrack(tracker, handle);
+	if (ACTIVE_COUNT(tracker) >= tracker->capacity) {
+		ret = fd_tracker_suspend_handles(tracker, 1);
+		if (ret) {
+			goto end;
+		}
+	}
+	ret = fs_handle_restore(handle);
+end:
+	fd_tracker_track(tracker, handle);
+	return ret ? ret : handle->fd;
+}
+
+int fs_handle_get_fd(struct fs_handle *handle)
+{
+	int ret;
+
+	pthread_mutex_lock(&handle->tracker->lock);
+	pthread_mutex_lock(&handle->lock);
+	assert(!handle->in_use);
+
+	handle->tracker->stats.uses++;
+	if (handle->fd >= 0) {
+		ret = handle->fd;
+		/* Mark as most recently used. */
+		fd_tracker_untrack(handle->tracker, handle);
+		fd_tracker_track(handle->tracker, handle);
+	} else {
+		handle->tracker->stats.misses++;
+		ret = fd_tracker_restore_handle(handle->tracker, handle);
+		if (ret < 0) {
+			handle->tracker->stats.errors++;
+			goto end;
+		}
+	}
+	handle->in_use = true;
+end:
+	pthread_mutex_unlock(&handle->lock);
+	pthread_mutex_unlock(&handle->tracker->lock);
+	return ret;
+}
+
+void fs_handle_put_fd(struct fs_handle *handle)
+{
+	pthread_mutex_lock(&handle->lock);
+	handle->in_use = false;
+	pthread_mutex_unlock(&handle->lock);
+}
+
+int fs_handle_close(struct fs_handle *handle)
+{
+	int ret = 0;
+
+	if (!handle) {
+		ret = -EINVAL;
+		goto end;
+	}
+
+	pthread_mutex_lock(&handle->tracker->lock);
+	pthread_mutex_lock(&handle->lock);
+	fd_tracker_untrack(handle->tracker, handle);
+	if (handle->fd >= 0) {
+		/*
+		 * The return value of close() is not propagated as there
+		 * isn't much the user can do about it.
+		 */
+		if (close(handle->fd)) {
+			PERROR("Failed to close the file descritptor (%d) of fs handle to %s, close() returned",
+					handle->fd, handle->properties.path);
+		}
+		handle->fd = -1;
+	}
+	pthread_mutex_unlock(&handle->lock);
+	pthread_mutex_destroy(&handle->lock);
+	pthread_mutex_unlock(&handle->tracker->lock);
+	free(handle->properties.path);
+	free(handle);
+end:
+	return ret;
+}

--- a/src/common/fd-tracker/fd-tracker.c
+++ b/src/common/fd-tracker/fd-tracker.c
@@ -754,6 +754,17 @@ int fs_handle_get_fd(struct fs_handle *handle)
 {
 	int ret;
 
+	/*
+	 * TODO This should be optimized as it is a fairly hot path.
+	 * The fd-tracker's lock should only be taken when a fs_handle is
+	 * restored (slow path). On the fast path (fs_handle is active),
+	 * the only effect on the fd_tracker is marking the handle as the
+	 * most recently used. Currently, it is done by a call to the
+	 * track/untrack helpers, but it should be done atomically.
+	 *
+	 * Note that the lock's nesting order must still be respected here.
+	 * The handle's lock nests inside the tracker's lock.
+	 */
 	pthread_mutex_lock(&handle->tracker->lock);
 	pthread_mutex_lock(&handle->lock);
 	assert(!handle->in_use);

--- a/src/common/fd-tracker/fd-tracker.c
+++ b/src/common/fd-tracker/fd-tracker.c
@@ -796,6 +796,18 @@ void fs_handle_put_fd(struct fs_handle *handle)
 	pthread_mutex_unlock(&handle->lock);
 }
 
+int fs_handle_unlink(struct fs_handle *handle)
+{
+	int ret;
+
+	pthread_mutex_lock(&handle->tracker->lock);
+	pthread_mutex_lock(&handle->lock);
+	ret = lttng_inode_defer_unlink(handle->inode);
+	pthread_mutex_unlock(&handle->lock);
+	pthread_mutex_unlock(&handle->tracker->lock);
+	return ret;
+}
+
 int fs_handle_close(struct fs_handle *handle)
 {
 	int ret = 0;

--- a/src/common/fd-tracker/fd-tracker.h
+++ b/src/common/fd-tracker/fd-tracker.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2018 - Jérémie Galarneau <jeremie.galarneau@efficios.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef FD_TRACKER_H
+#define FD_TRACKER_H
+
+#include <stdint.h>
+#include <sys/types.h>
+
+struct fs_handle;
+struct fd_tracker;
+
+/*
+ * Callback which returns a file descriptor to track through the fd
+ * tracker. This callback must not make use of the fd_tracker as a deadlock
+ * may occur.
+ *
+ * The int pointer argument is an output parameter that should be used to return
+ * the advertised number of file descriptors.
+ *
+ * Must return zero on success. Negative values should map to a UNIX error code.
+ */
+typedef int (*fd_open_cb)(void *, int *out_fds);
+
+/*
+ * Callback to allow the user to close a now-untracked file descriptor. This
+ * callback must not make use of the fd_tracker as a deadlock may occur.
+ *
+ * The callback can freely modify the in_fds argument as it is copied by the
+ * fd_tracker before being used. The fd tracker assumes in_fds to be closed by
+ * the time the callback returns.
+ *
+ * Must return zero on success. Negative values should map to a UNIX error code.
+ */
+typedef int (*fd_close_cb)(void *, int *in_fds);
+
+/*
+ * Set the maximal number of fds that the process should be allowed to open at
+ * any given time. This function must be called before any other of this
+ * interface.
+ */
+struct fd_tracker *fd_tracker_create(unsigned int capacity);
+
+/* Returns an error if file descriptors are leaked. */
+int fd_tracker_destroy(struct fd_tracker *tracker);
+
+/*
+ * Open a handle to a suspendable filesystem file descriptor.
+ *
+ * See OPEN(3) for an explanation of flags and mode. NULL is returned in case of
+ * error and errno is left untouched. Note that passing NULL as mode will result
+ * in open()'s default behaviour being used (using the process' umask).
+ *
+ * A fs_handle wraps a file descriptor created by OPEN(3). It is suspendable
+ * meaning that the underlying file may be closed at any time unless the
+ * handle is marked as being in-use (see fs_handle_get_fd() and
+ * fs_handle_put_fd()).
+ *
+ * If the tracker opted to close the underlying file descriptor, it will
+ * be restored to its last known state when it is obtained through
+ * the fs_handle's fs_handle_get_fd() method.
+ *
+ * Note that a suspendable file descriptor can be closed by the fd tracker at
+ * anytime when it is not in use. This means that the user should not rely on it
+ * being safe to unlink the file. Moreover, concurent modifications to the file
+ * (e.g. truncation) may react differently than if the file descriptor was kept
+ * open.
+ */
+struct fs_handle *fd_tracker_open_fs_handle(struct fd_tracker *tracker,
+		const char *path, int flags, mode_t *mode);
+
+/*
+ * Open a tracked unsuspendable file descriptor.
+ *
+ * This function allows the fd tracker to keep track of unsuspendable
+ * file descriptors. A callback, open, is passed to allow the tracker
+ * to atomically reserve an entry for a given count of new file descriptors,
+ * suspending file descriptors as needed, and invoke the provided callback
+ * without ever exceeding the tracker's capacity.
+ *
+ * fd_count indicates the count of file descriptors that will be opened and
+ * returned by the open callback. The storage location at out_fds is assumed
+ * to be large enough to hold 'fd_count * sizeof(int)'.
+ *
+ * Names may be provided to allow easier debugging of file descriptor
+ * exhaustions.
+ *
+ * The callback's return value is returned to the user. Additionally, two
+ * negative tracker-specific codes may be returned:
+ *   - ENOMEM: allocation of a new entry failed,
+ *   - EMFILE: too many unsuspendable fds are opened and the tracker can't
+ *             accomodate the request for a new unsuspendable entry.
+ */
+int fd_tracker_open_unsuspendable_fd(struct fd_tracker *tracker,
+		int *out_fds, const char **names, unsigned int fd_count,
+		fd_open_cb open, void *data);
+
+/*
+ * Close a tracked unsuspendable file descriptor.
+ *
+ * This function allows the fd tracker to keep track of unsuspendable
+ * file descriptors. A callback, close, is passed to allow the tracker
+ * to atomically release a file descriptor entry.
+ *
+ * Returns 0 if the close callback returned success. Returns the value returned
+ * by the close callback if it is negative. Additionally, a tracker-specific
+ * code may be returned:
+ *   - EINVAL: a file descriptor was unknown to the tracker
+ *
+ * Closed fds are set to -1 in the fds array which, in the event of an error,
+ * allows the user to know which file descriptors are no longer being tracked.
+ */
+int fd_tracker_close_unsuspendable_fd(struct fd_tracker *tracker,
+		int *fds, unsigned int fd_count, fd_close_cb close,
+		void *data);
+
+/*
+ * Log the contents of the fd_tracker.
+ */
+void fd_tracker_log(struct fd_tracker *tracker);
+
+/*
+ * Marks the handle as the most recently used and marks the 'fd' as
+ * "in-use". This prevents the tracker from recycling the underlying
+ * file descriptor while it is actively being used by a thread.
+ *
+ * Don't forget that the tracker may be initiating an fd 'suspension'
+ * from another thread as the need to free an fd slot may arise from any
+ * thread within the daemon.
+ *
+ * Note that a restorable fd should never be held for longer than
+ * strictly necessary (e.g. the duration of a syscall()).
+ *
+ * Returns the fd on success, otherwise a negative value may be returned
+ * if the restoration of the fd failed.
+ */
+int fs_handle_get_fd(struct fs_handle *handle);
+
+/*
+ * Used by the application to signify that it is no longer using the
+ * underlying fd and that it may be suspended.
+ */
+void fs_handle_put_fd(struct fs_handle *handle);
+
+/*
+ * Frees the handle and discards the underlying fd.
+ */
+int fs_handle_close(struct fs_handle *handle);
+
+#endif /* FD_TRACKER_H */

--- a/src/common/fd-tracker/fd-tracker.h
+++ b/src/common/fd-tracker/fd-tracker.h
@@ -157,6 +157,20 @@ int fs_handle_get_fd(struct fs_handle *handle);
 void fs_handle_put_fd(struct fs_handle *handle);
 
 /*
+ * Unlink the file associated to an fs_handle. Note that the unlink
+ * operation will not be performed immediately. It will only be performed
+ * once all references to the underlying file (through other fs_handle objects)
+ * have been released.
+ *
+ * However, note that the file will be renamed so as to provide the observable
+ * effect of an unlink(), that is removing a name from the filesystem.
+ *
+ * Returns 0 on success, otherwise a negative value will be returned
+ * if the operation failed.
+ */
+int fs_handle_unlink(struct fs_handle *handle);
+
+/*
  * Frees the handle and discards the underlying fd.
  */
 int fs_handle_close(struct fs_handle *handle);

--- a/src/common/fd-tracker/inode.c
+++ b/src/common/fd-tracker/inode.c
@@ -1,0 +1,348 @@
+/*
+ * Copyright (C) 2018 - Jérémie Galarneau <jeremie.galarneau@efficios.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <inttypes.h>
+#include <urcu.h>
+#include <urcu/ref.h>
+#include <urcu/rculfhash.h>
+#include <common/hashtable/utils.h>
+#include <common/macros.h>
+#include <common/defaults.h>
+#include <common/error.h>
+#include <lttng/constant.h>
+
+#include "inode.h"
+
+struct inode_id {
+	dev_t device;
+	ino_t inode;
+};
+
+struct lttng_inode_registry {
+	/* Hashtable of inode_id to lttng_inode. */
+	struct cds_lfht *inodes;
+};
+
+struct lttng_inode {
+	struct inode_id id;
+	char *path;
+	bool unlink_pending;
+	/* Node in the lttng_inode_registry's ht. */
+	struct cds_lfht_node registry_node;
+	/* Weak reference to ht containing the node. */
+	struct cds_lfht *registry_ht;
+	struct urcu_ref ref;
+	struct rcu_head rcu_head;
+};
+
+static struct {
+	pthread_mutex_t lock;
+	bool initialized;
+	unsigned long value;
+} seed = {
+	.lock = PTHREAD_MUTEX_INITIALIZER,
+};
+
+static
+unsigned long lttng_inode_id_hash(struct inode_id *id)
+{
+	uint64_t device = id->device, inode_no = id->inode;
+
+        return hash_key_u64(&device, seed.value) ^
+			hash_key_u64(&inode_no, seed.value);
+}
+
+static
+int lttng_inode_match(struct cds_lfht_node *node, const void *key)
+{
+	const struct inode_id *id = key;
+	struct lttng_inode *inode = caa_container_of(node, struct lttng_inode,
+			registry_node);
+
+	return inode->id.device == id->device && inode->id.inode == id->inode;
+}
+
+static
+void lttng_inode_delete(struct rcu_head *head)
+{
+	struct lttng_inode *inode = caa_container_of(head,
+			struct lttng_inode, rcu_head);
+
+	free(inode->path);
+	free(inode);
+}
+
+static
+void lttng_inode_destroy(struct lttng_inode *inode)
+{
+	if (!inode) {
+		return;
+	}
+	if (inode->unlink_pending) {
+		int ret = unlink(inode->path);
+
+		DBG("Unlinking %s during lttng_inode destruction", inode->path);
+		if (ret) {
+			PERROR("Failed to unlink %s", inode->path);
+		}
+	}
+	call_rcu(&inode->rcu_head, lttng_inode_delete);
+}
+
+static
+void lttng_inode_release(struct urcu_ref *ref)
+{
+        lttng_inode_destroy(caa_container_of(ref, struct lttng_inode, ref));
+}
+
+static
+void lttng_inode_get(struct lttng_inode *inode)
+{
+	urcu_ref_get(&inode->ref);
+}
+
+void lttng_inode_put(struct lttng_inode *inode)
+{
+	urcu_ref_put(&inode->ref, lttng_inode_release);
+}
+
+const char *lttng_inode_get_path(const struct lttng_inode *inode)
+{
+	return inode->path;
+}
+
+int lttng_inode_rename(struct lttng_inode *inode, const char *new_path,
+	bool overwrite)
+{
+	int ret = 0;
+	char *new_path_copy = NULL;
+
+	if (inode->unlink_pending) {
+		WARN("An attempt to rename an unlinked file, %s to %s, has been performed",
+				inode->path, new_path);
+		ret = -ENOENT;
+		goto end;
+	}
+
+	if (!overwrite) {
+		struct stat statbuf;
+
+		ret = stat(new_path, &statbuf);
+		if (ret == 0) {
+			ret = -EEXIST;
+			goto end;
+		} else if (ret < 0 && errno != ENOENT) {
+			PERROR("Failed to stat() %s", new_path);
+			ret = -errno;
+			goto end;
+		}
+	}
+
+	new_path_copy = strdup(new_path);
+	if (!new_path_copy) {
+		ERR("Failed to allocate storage for path %s", new_path);
+		ret = -ENOMEM;
+		goto end;
+	}
+
+	ret = rename(inode->path, new_path);
+	if (ret) {
+		PERROR("Failed to rename %s to %s", inode->path, new_path);
+		ret = -errno;
+		goto end;
+	}
+
+	free(inode->path);
+	inode->path = new_path_copy;
+	new_path_copy = NULL;
+end:
+	free(new_path_copy);
+	return ret;
+}
+
+int lttng_inode_defer_unlink(struct lttng_inode *inode)
+{
+	int ret = 0;
+	uint16_t i = 0;
+	char suffix[sizeof("-deleted-65535")] = "-deleted";
+	char new_path[LTTNG_PATH_MAX];
+	size_t original_path_len = strlen(inode->path);
+
+	if (inode->unlink_pending) {
+		WARN("An attempt to re-unlink %s has been performed, ignoring.",
+				inode->path);
+		ret = -ENOENT;
+		goto end;
+	}
+
+	ret = lttng_strncpy(new_path, inode->path, sizeof(new_path));
+	if (ret < 0) {
+		ret = -ENAMETOOLONG;
+		goto end;
+	}
+
+	for (i = 0; i < UINT16_MAX; i++) {
+		int p_ret;
+
+		if (i != 0) {
+			p_ret = snprintf(suffix, sizeof(suffix), "-deleted-%" PRIu16, i);
+
+			if (p_ret < 0) {
+				PERROR("Failed to form suffix to rename file %s",
+						inode->path);
+				ret = -errno;
+				goto end;
+			}
+			assert(p_ret != sizeof(suffix));
+		} else {
+			/* suffix is initialy set to '-deleted'. */
+			p_ret = strlen(suffix);
+		}
+
+		if (original_path_len + p_ret + 1 >= sizeof(new_path)) {
+			ret = -ENAMETOOLONG;
+			goto end;
+		}
+
+		strcat(&new_path[original_path_len], suffix);
+		ret = lttng_inode_rename(inode, new_path, false);
+		if (ret != -EEXIST) {
+			break;
+		}
+		new_path[original_path_len] = '\0';
+	}
+	if (!ret) {
+		inode->unlink_pending = true;
+	}
+end:
+	return ret;
+}
+
+static
+struct lttng_inode *lttng_inode_create(const struct inode_id *id,
+		const char *path, struct cds_lfht *ht)
+{
+	struct lttng_inode *inode = zmalloc(sizeof(*inode));
+
+	if (!inode) {
+		goto end;
+	}
+
+	urcu_ref_init(&inode->ref);
+	cds_lfht_node_init(&inode->registry_node);
+	inode->id = *id;
+	inode->path = strdup(path);
+	if (!inode->path) {
+		goto error;
+	}
+end:
+	return inode;
+error:
+	lttng_inode_destroy(inode);
+	return NULL;
+}
+
+struct lttng_inode_registry *lttng_inode_registry_create(void)
+{
+	struct lttng_inode_registry *registry = zmalloc(sizeof(*registry));
+
+	if (!registry) {
+		goto end;
+	}
+
+	pthread_mutex_lock(&seed.lock);
+	if (!seed.initialized) {
+		seed.value = (unsigned long) time(NULL);
+		seed.initialized = true;
+	}
+	pthread_mutex_unlock(&seed.lock);
+
+	registry->inodes = cds_lfht_new(DEFAULT_HT_SIZE, 1, 0,
+			CDS_LFHT_AUTO_RESIZE | CDS_LFHT_ACCOUNTING, NULL);
+	if (!registry->inodes) {
+		goto error;
+	}
+end:
+	return registry;
+error:
+	lttng_inode_registry_destroy(registry);
+	return NULL;
+}
+
+void lttng_inode_registry_destroy(struct lttng_inode_registry *registry)
+{
+	if (!registry) {
+		return;
+	}
+	if (registry->inodes) {
+		int ret = cds_lfht_destroy(registry->inodes, NULL);
+
+		assert(!ret);
+	}
+	free(registry);
+}
+
+struct lttng_inode *lttng_inode_registry_get_inode(
+		struct lttng_inode_registry *registry,
+		int fd, const char *path)
+{
+	int ret;
+	struct stat statbuf;
+	struct inode_id id;
+	struct cds_lfht_iter iter;
+	struct cds_lfht_node *node;
+	struct lttng_inode *inode = NULL;
+
+	ret = fstat(fd, &statbuf);
+	if (ret < 0) {
+		PERROR("stat() failed on file %s, fd = %i", path, fd);
+		goto end;
+	}
+
+	id.device = statbuf.st_dev;
+	id.inode = statbuf.st_ino;
+
+	rcu_read_lock();
+	cds_lfht_lookup(registry->inodes,
+			lttng_inode_id_hash(&id),
+			lttng_inode_match,
+		        &id,
+			&iter);
+	node = cds_lfht_iter_get_node(&iter);
+	if (node) {
+	        inode = caa_container_of(node, struct lttng_inode, registry_node);
+		/* Renames should happen through the fs-handle interface. */
+		assert(!strcmp(path, inode->path));
+		lttng_inode_get(inode);
+		goto end_unlock;
+	}
+
+	inode = lttng_inode_create(&id, path, registry->inodes);
+	node = cds_lfht_add_unique(registry->inodes,
+			lttng_inode_id_hash(&inode->id),
+			lttng_inode_match,
+			&inode->id,
+			&inode->registry_node);
+	assert(node == &inode->registry_node);
+end_unlock:
+	rcu_read_unlock();
+end:
+	return inode;
+}

--- a/src/common/fd-tracker/inode.c
+++ b/src/common/fd-tracker/inode.c
@@ -103,6 +103,9 @@ void lttng_inode_destroy(struct lttng_inode *inode)
 			PERROR("Failed to unlink %s", inode->path);
 		}
 	}
+	rcu_read_lock();
+	cds_lfht_del(inode->registry_ht, &inode->registry_node);
+	rcu_read_unlock();
 	call_rcu(&inode->rcu_head, lttng_inode_delete);
 }
 
@@ -249,6 +252,7 @@ struct lttng_inode *lttng_inode_create(const struct inode_id *id,
 	cds_lfht_node_init(&inode->registry_node);
 	inode->id = *id;
 	inode->path = strdup(path);
+	inode->registry_ht = ht;
 	if (!inode->path) {
 		goto error;
 	}

--- a/src/common/fd-tracker/inode.h
+++ b/src/common/fd-tracker/inode.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 - Jérémie Galarneau <jeremie.galarneau@efficios.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef FD_TRACKER_INODE_H
+#define FD_TRACKER_INODE_H
+
+#include <stdbool.h>
+
+struct lttng_inode;
+struct lttng_inode_registry;
+
+/* The inode registry is protected by the fd-tracker's lock. */
+struct lttng_inode_registry *lttng_inode_registry_create(void);
+
+struct lttng_inode *lttng_inode_registry_get_inode(
+		struct lttng_inode_registry *registry, int fd,
+		const char *path);
+
+void lttng_inode_registry_destroy(struct lttng_inode_registry *registry);
+
+const char *lttng_inode_get_path(const struct lttng_inode *inode);
+int lttng_inode_rename(struct lttng_inode *inode, const char *new_path,
+		bool overwrite);
+int lttng_inode_defer_unlink(struct lttng_inode *inode);
+void lttng_inode_put(struct lttng_inode *inode);
+
+#endif /* FD_TRACKER_INODE_H */

--- a/src/common/fd-tracker/utils-epoll.c
+++ b/src/common/fd-tracker/utils-epoll.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018 - Jérémie Galarneau <jeremie.galarneau@efficios.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <common/compat/poll.h>
+
+#include "utils.h"
+
+struct create_args {
+	struct lttng_poll_event *events;
+	int size;
+	int flags;
+};
+
+static
+int open_epoll(void *data, int *out_fd)
+{
+	int ret;
+	struct create_args *args = data;
+
+	ret = lttng_poll_create(args->events, args->size, args->flags);
+	if (ret < 0) {
+		goto end;
+	}
+
+	*out_fd = args->events->epfd;
+end:
+	return ret;
+}
+
+static
+int close_epoll(void *data, int *in_fd)
+{
+	/* Will close the epfd. */
+	lttng_poll_clean((struct lttng_poll_event *) data);
+	return 0;
+}
+
+/*
+ * The epoll variant of the poll compat layer creates an unsuspendable fd which
+ * must be tracked.
+ */
+int fd_tracker_util_poll_create(struct fd_tracker *tracker, const char *name,
+		struct lttng_poll_event *events, int size, int flags)
+{
+	int out_fd;
+	struct create_args create_args = {
+		.events = events,
+		.size = size,
+		.flags = flags,
+	};
+
+	return fd_tracker_open_unsuspendable_fd(tracker, &out_fd, &name, 1,
+			open_epoll, &create_args);
+}
+
+int fd_tracker_util_poll_clean(struct fd_tracker *tracker,
+		struct lttng_poll_event *events)
+{
+	return fd_tracker_close_unsuspendable_fd(tracker, &events->epfd, 1,
+			close_epoll, events);
+}

--- a/src/common/fd-tracker/utils-poll.c
+++ b/src/common/fd-tracker/utils-poll.c
@@ -15,25 +15,23 @@
  * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef FD_TRACKER_UTILS_H
-#define FD_TRACKER_UTILS_H
+#include <common/compat/poll.h>
 
-#include <common/fd-tracker/fd-tracker.h>
-
-struct lttng_poll_event;
+#include "utils.h"
 
 /*
- * Utility implementing a close_fd callback which receives one file descriptor
- * and closes it, returning close()'s return value.
+ * The epoll variant of the poll compat layer creates an unsuspendable fd which
+ * must be tracked.
  */
-int fd_tracker_util_close_fd(void *, int *fd);
+int fd_tracker_util_poll_create(struct fd_tracker *tracker,
+		struct lttng_poll_event *events, int size, int flags)
+{
+	return lttng_poll_create(events, size, flags);
+}
 
-/*
- * Create a poll event and track its underlying fd, if applicable.
- */
-int fd_tracker_util_poll_create(struct fd_tracker *tracker, const char *name,
-		struct lttng_poll_event *events, int size, int flags);
 int fd_tracker_util_poll_clean(struct fd_tracker *tracker,
-		struct lttng_poll_event *events);
-
-#endif /* FD_TRACKER_UTILS_H */
+		struct lttng_poll_event *events)
+{
+	lttng_poll_clean(events);
+	return 0;
+}

--- a/src/common/fd-tracker/utils-poll.c
+++ b/src/common/fd-tracker/utils-poll.c
@@ -23,7 +23,7 @@
  * The epoll variant of the poll compat layer creates an unsuspendable fd which
  * must be tracked.
  */
-int fd_tracker_util_poll_create(struct fd_tracker *tracker,
+int fd_tracker_util_poll_create(struct fd_tracker *tracker, const char *name,
 		struct lttng_poll_event *events, int size, int flags)
 {
 	return lttng_poll_create(events, size, flags);

--- a/src/common/fd-tracker/utils.c
+++ b/src/common/fd-tracker/utils.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2018 - Jérémie Galarneau <jeremie.galarneau@efficios.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <unistd.h>
+#include <common/fd-tracker/utils.h>
+
+int fd_tracker_util_close_fd(void *unused, int *fd)
+{
+	return close(*fd);
+}

--- a/src/common/fd-tracker/utils.c
+++ b/src/common/fd-tracker/utils.c
@@ -16,9 +16,64 @@
  */
 
 #include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <common/fd-tracker/utils.h>
+#include <common/utils.h>
+
+static
+int open_pipe_cloexec(void *data, int *fds)
+{
+	int ret;
+
+	ret = utils_create_pipe_cloexec(fds);
+	if (ret < 0) {
+		goto end;
+	}
+end:
+	return ret;
+}
+
+static
+int close_pipe(void *data, int *pipe)
+{
+	utils_close_pipe(pipe);
+	pipe[0] = pipe[1] = -1;
+	return 0;
+}
 
 int fd_tracker_util_close_fd(void *unused, int *fd)
 {
 	return close(*fd);
+}
+
+int fd_tracker_util_pipe_open_cloexec(struct fd_tracker *tracker,
+		const char *name, int *pipe)
+{
+	int ret;
+	const char *name_prefix;
+	char *names[2];
+
+	name_prefix = name ? name : "Unknown pipe";
+	ret = asprintf(&names[0], "%s (read end)", name_prefix);
+	if (ret < 0) {
+		goto end;
+	}
+	ret = asprintf(&names[1], "%s (write end)", name_prefix);
+	if (ret < 0) {
+		goto end;
+	}
+
+        ret = fd_tracker_open_unsuspendable_fd(tracker, pipe,
+			(const char **) names, 2, open_pipe_cloexec, NULL);
+	free(names[0]);
+	free(names[1]);
+end:
+	return ret;
+}
+
+int fd_tracker_util_pipe_close(struct fd_tracker *tracker, int *pipe)
+{
+        return fd_tracker_close_unsuspendable_fd(tracker,
+			pipe, 2, close_pipe, NULL);
 }

--- a/src/common/fd-tracker/utils.h
+++ b/src/common/fd-tracker/utils.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018 - Jérémie Galarneau <jeremie.galarneau@efficios.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef FD_TRACKER_UTILS_H
+#define FD_TRACKER_UTILS_H
+
+/*
+ * Utility implementing a close_fd callback which receives one file descriptor
+ * and closes it, returning close()'s return value.
+ */
+int fd_tracker_util_close_fd(void *, int *fd);
+
+#endif /* FD_TRACKER_UTILS_H */

--- a/src/common/fd-tracker/utils.h
+++ b/src/common/fd-tracker/utils.h
@@ -29,6 +29,13 @@ struct lttng_poll_event;
 int fd_tracker_util_close_fd(void *, int *fd);
 
 /*
+ * Create a pipe and track its underlying fds.
+ */
+int fd_tracker_util_pipe_open_cloexec(struct fd_tracker *tracker,
+		const char *name, int *pipe);
+int fd_tracker_util_pipe_close(struct fd_tracker *tracker, int *pipe);
+
+/*
  * Create a poll event and track its underlying fd, if applicable.
  */
 int fd_tracker_util_poll_create(struct fd_tracker *tracker, const char *name,

--- a/src/common/index/ctf-index.h
+++ b/src/common/index/ctf-index.h
@@ -25,7 +25,12 @@
 #ifndef LTTNG_INDEX_H
 #define LTTNG_INDEX_H
 
+#include <common/compat/endian.h>
+#include <common/macros.h>
+
+#include <stdint.h>
 #include <limits.h>
+#include <stddef.h>
 
 #define CTF_INDEX_MAGIC 0xC1F1DCC1
 #define CTF_INDEX_MAJOR 1
@@ -99,6 +104,18 @@ static inline uint32_t lttng_to_index_minor(uint32_t lttng_major,
 		}
 	}
 	abort();
+}
+
+static inline void ctf_packet_index_file_hdr_init(
+		struct ctf_packet_index_file_hdr *hdr,
+		uint32_t idx_major, uint32_t idx_minor)
+{
+	memset(hdr, 0, sizeof(*hdr));
+	hdr->magic = htobe32(CTF_INDEX_MAGIC);
+	hdr->index_major = htobe32(idx_major);
+	hdr->index_minor = htobe32(idx_minor);
+	hdr->packet_index_len = htobe32(
+			ctf_packet_index_len(idx_major, idx_minor));
 }
 
 #endif /* LTTNG_INDEX_H */

--- a/src/common/index/index.c
+++ b/src/common/index/index.c
@@ -88,11 +88,7 @@ struct lttng_index_file *lttng_index_file_create(char *path_name,
 	}
 	fd = ret;
 
-	hdr.magic = htobe32(CTF_INDEX_MAGIC);
-	hdr.index_major = htobe32(major);
-	hdr.index_minor = htobe32(minor);
-	hdr.packet_index_len = htobe32(element_len);
-
+	ctf_packet_index_file_hdr_init(&hdr, major, minor);
 	size_ret = lttng_write(fd, &hdr, sizeof(hdr));
 	if (size_ret < sizeof(hdr)) {
 		PERROR("write index header");

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <getopt.h>
+#include <stdbool.h>
 
 #define KIBI_LOG2 10
 #define MEBI_LOG2 20
@@ -39,10 +40,15 @@ int utils_set_fd_cloexec(int fd);
 int utils_create_pid_file(pid_t pid, const char *filepath);
 int utils_mkdir(const char *path, mode_t mode, int uid, int gid);
 int utils_mkdir_recursive(const char *path, mode_t mode, int uid, int gid);
+int utils_stream_file_name(char *path, const char *path_name,
+		const char *file_name, uint64_t size, uint64_t count,
+		const char *suffix);
 int utils_create_stream_file(const char *path_name, char *file_name, uint64_t size,
 		uint64_t count, int uid, int gid, char *suffix);
 int utils_unlink_stream_file(const char *path_name, char *file_name, uint64_t size,
 		uint64_t count, int uid, int gid, char *suffix);
+void utils_stream_file_rotation_get_new_count(uint64_t count,
+		uint64_t *new_count, bool *should_unlink);
 int utils_rotate_stream_file(char *path_name, char *file_name, uint64_t size,
 		uint64_t count, int uid, int gid, int out_fd, uint64_t *new_count,
 		int *stream_fd);

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -14,12 +14,14 @@ TESTS = test_kernel_data \
 	test_utils_expand_path \
 	test_string_utils \
 	test_notification \
-	ini_config/test_ini_config
+	ini_config/test_ini_config \
+	test_fd_tracker
 
 LIBTAP=$(top_builddir)/tests/utils/tap/libtap.la
 
 LIBCOMMON=$(top_builddir)/src/common/libcommon.la
 LIBSTRINGUTILS=$(top_builddir)/src/common/string-utils/libstring-utils.la
+LIBFDTRACKER=$(top_builddir)/src/common/fd-tracker/libfd-tracker.la
 LIBSESSIOND_COMM=$(top_builddir)/src/common/sessiond-comm/libsessiond-comm.la
 LIBHASHTABLE=$(top_builddir)/src/common/hashtable/libhashtable.la
 LIBRELAYD=$(top_builddir)/src/common/relayd/librelayd.la
@@ -28,7 +30,8 @@ LIBLTTNG_CTL=$(top_builddir)/src/lib/lttng-ctl/liblttng-ctl.la
 # Define test programs
 noinst_PROGRAMS = test_uri test_session test_kernel_data \
                   test_utils_parse_size_suffix test_utils_parse_time_suffix \
-                  test_utils_expand_path test_string_utils test_notification
+                  test_utils_expand_path test_string_utils test_notification \
+                  test_fd_tracker
 
 if HAVE_LIBLTTNG_UST_CTL
 noinst_PROGRAMS += test_ust_data
@@ -122,3 +125,7 @@ test_string_utils_LDADD = $(LIBTAP) $(LIBCOMMON) $(LIBSTRINGUTILS) $(DL_LIBS)
 # Notification api
 test_notification_SOURCES = test_notification.c
 test_notification_LDADD = $(LIBTAP) $(LIBLTTNG_CTL) $(DL_LIBS)
+
+# fd tracker unit test
+test_fd_tracker_SOURCES = test_fd_tracker.c
+test_fd_tracker_LDADD = $(LIBTAP) $(LIBFDTRACKER) $(DL_LIBS) -lurcu $(LIBCOMMON) $(LIBHASHTABLE)

--- a/tests/unit/test_fd_tracker.c
+++ b/tests/unit/test_fd_tracker.c
@@ -1,0 +1,661 @@
+/*
+ * Copyright (c) - 2018 Jérémie Galarneau <jeremie.galarneau@efficios.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by as
+ * published by the Free Software Foundation; only version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdlib.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <assert.h>
+#include <string.h>
+#include <stdarg.h>
+#include <tap/tap.h>
+#include <sys/types.h>
+#include <dirent.h>
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+
+#include <common/fd-tracker/fd-tracker.h>
+#include <common/error.h>
+
+/* For error.h */
+int lttng_opt_quiet = 1;
+int lttng_opt_verbose;
+int lttng_opt_mi;
+
+/* Number of TAP tests in this file */
+#define NUM_TESTS 35
+/* 3 for stdin, stdout, and stderr */
+#define STDIO_FD_COUNT 3
+#define TRACKER_FD_LIMIT 50
+#define TMP_DIR_PATTERN "/tmp/fd-tracker-XXXXXX"
+
+/*
+ * Count of fds, beyond stdin, stderr, stdout that were open
+ * at the launch of the test. This allows the test to succeed when
+ * run by automake's test runner or valgrind which both open
+ * fds behind our back.
+ */
+int unknown_fds_count;
+
+const char file_contents[] = "Bacon ipsum dolor amet jerky drumstick sirloin "
+	"strip steak venison boudin filet mignon picanha doner shoulder. "
+	"Strip steak brisket alcatra, venison beef chuck cupim pastrami. "
+	"Landjaeger tri-tip salami leberkas ball tip, ham hock chuck sausage "
+	"flank jerky cupim. Pig bacon chuck pancetta andouille.";
+
+int fd_count(void)
+{
+	DIR *dir;
+	struct dirent *entry;
+        int count = 0;
+
+	dir = opendir("/proc/self/fd");
+	if (!dir) {
+		perror("# Failed to enumerate /proc/self/fd/ to count the number of used file descriptors");
+	        count = -1;
+		goto end;
+	}
+
+	while ((entry = readdir(dir)) != NULL) {
+		if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, "..")) {
+			continue;
+		}
+	        count++;
+	}
+	/* Don't account for the file descriptor opened by opendir(). */
+        count--;
+	closedir(dir);
+end:
+	return count;
+}
+
+static
+void check_fd_count(int expected_count)
+{
+        int count = 0;
+
+        count = fd_count();
+	ok(count == expected_count, "Expected %d open file descriptors (%d are open)",
+			expected_count, count);
+}
+
+static
+int noop_open(void *data, int *fds)
+{
+        *fds = *((int *) data);
+	return 0;
+}
+
+static
+int noop_close(void *data, int *fds)
+{
+	return 0;
+}
+
+static
+void track_std_fds(struct fd_tracker *tracker)
+{
+	int i;
+        struct { int fd; const char *name; } files[] = {
+		{ .fd = fileno(stdin), .name = "stdin" },
+		{ .fd = fileno(stdout), .name = "stdout" },
+		{ .fd = fileno(stderr), .name = "stderr" },
+	};
+
+	for (i = 0; i < sizeof(files) / sizeof(*files); i++) {
+		int out_fd, ret;
+
+		ret = fd_tracker_open_unsuspendable_fd(tracker, &out_fd,
+				&files[i].name, 1, noop_open, &files[i].fd);
+		assert(out_fd == files[i].fd);
+
+		ok(ret == 0, "Track unsuspendable fd %d (%s)", files[i].fd,
+				files[i].name);
+	}
+}
+
+static
+void untrack_std_fds(struct fd_tracker *tracker)
+{
+	int i;
+        struct { int fd; const char *name; } files[] = {
+		{ .fd = fileno(stdin), .name = "stdin" },
+		{ .fd = fileno(stdout), .name = "stdout" },
+		{ .fd = fileno(stderr), .name = "stderr" },
+	};
+	unsigned int fds_set_to_minus_1 = 0;
+
+	for (i = 0; i < sizeof(files) / sizeof(*files); i++) {
+		int fd = files[i].fd;
+		int ret = fd_tracker_close_unsuspendable_fd(tracker,
+				&files[i].fd, 1, noop_close, NULL);
+
+		ok(ret == 0, "Untrack unsuspendable fd %d (%s)", fd,
+				files[i].name);
+		fds_set_to_minus_1 += (files[i].fd == -1);
+	}
+}
+
+/*
+ * Basic test opening and closing three unsuspendable fds. 
+ */
+static
+void test_unsuspendable_basic(void)
+{
+	struct fd_tracker *tracker;
+
+        tracker = fd_tracker_create(TRACKER_FD_LIMIT);
+	ok(tracker, "Created an fd tracker with a limit of %d simulateously opened file descriptors",
+			TRACKER_FD_LIMIT);
+	if (!tracker) {
+		return;
+	}
+
+	track_std_fds(tracker);
+	untrack_std_fds(tracker);
+
+	fd_tracker_destroy(tracker);
+}
+
+static
+int error_open(void *data, int *fds)
+{
+	return *((int *) data);
+}
+
+static
+int error_close(void *data, int *fds)
+{
+	return *((int *) data);
+}
+
+/*
+ * Validate that user callback return values are returned to the
+ * caller of the fd tracker.
+ */
+static
+void test_unsuspendable_cb_return(void)
+{
+	int ret, stdout_fd = fileno(stdout), out_fd = 42;
+	struct fd_tracker *tracker;
+	int expected_error = -ENETDOWN;
+
+        tracker = fd_tracker_create(TRACKER_FD_LIMIT);
+	assert(tracker);
+
+	/* The error_open callback should fail and return 'expected_error'. */
+	ret = fd_tracker_open_unsuspendable_fd(tracker, &out_fd,
+			NULL, 1, error_open, &expected_error);
+	ok(ret == expected_error, "fd_tracker_open_unsuspendable_fd() forwards the user callback's error code");
+	ok(out_fd == 42, "Output fd parameter is unaffected on error of fd_tracker_open_unsuspendable_fd()");
+
+	/*
+	 * Track a valid fd since we don't want the tracker to fail with an
+	 * invalid fd error for this test.
+	 */
+	ret = fd_tracker_open_unsuspendable_fd(tracker, &out_fd,
+			NULL, 1, noop_open, &stdout_fd);
+	ok(out_fd == stdout_fd, "fd_tracker_open_unsuspendable_fd() sets the output fd parameter to the newly-tracked fd's value");
+	assert(!ret);
+
+	ret = fd_tracker_close_unsuspendable_fd(tracker,
+			&stdout_fd, 1, error_close, &expected_error);
+	ok(ret == expected_error, "fd_tracker_close_unsuspendable_fd() forwards the user callback's error code");
+	ret = fd_tracker_close_unsuspendable_fd(tracker,
+			&stdout_fd, 1, noop_close, &expected_error);
+	assert(!ret);
+
+	fd_tracker_destroy(tracker);
+}
+
+/*
+ * Validate that the tracker refuses to track two identical unsuspendable
+ * file descriptors.
+ */
+static
+void test_unsuspendable_duplicate(void)
+{
+	int ret, stdout_fd = fileno(stdout), out_fd;
+	struct fd_tracker *tracker;
+
+        tracker = fd_tracker_create(TRACKER_FD_LIMIT);
+	assert(tracker);
+
+	ret = fd_tracker_open_unsuspendable_fd(tracker, &out_fd,
+			NULL, 1, noop_open, &stdout_fd);
+	assert(!ret);
+	ret = fd_tracker_open_unsuspendable_fd(tracker, &out_fd,
+			NULL, 1, noop_open, &stdout_fd);
+	ok(ret == -EEXIST, "EEXIST reported on open of an already tracked file descriptor");
+
+	ret = fd_tracker_close_unsuspendable_fd(tracker,
+			&stdout_fd, 1, noop_close, NULL);
+	assert(!ret);
+
+	fd_tracker_destroy(tracker);
+}
+
+static
+int open_pipes(void *data, int *out_fds)
+{
+	unsigned int i;
+	const unsigned int pipe_count = TRACKER_FD_LIMIT / 2;
+
+	for (i = 0; i < pipe_count; i++) {
+		int ret = pipe(&out_fds[i * 2]);
+
+		if (ret) {
+			return -errno;
+		}
+	}
+	return 0;
+}
+
+static
+int close_pipes(void *data, int *fds)
+{
+	int i;
+	int *pipes = fds;
+
+	for (i = 0; i < TRACKER_FD_LIMIT; i++) {
+		int ret = close(pipes[i]);
+
+		if (ret) {
+			return -errno;
+		}
+	}
+	return 0;
+}
+
+/*
+ * Validate that the tracker enforces the open file descriptor limit
+ * when unsuspendable file descritptors are being opened.
+ */
+static
+void test_unsuspendable_limit(void)
+{
+	struct fd_tracker *tracker;
+	int ret, stdout_fd = fileno(stdout), out_fd;
+	int fds[TRACKER_FD_LIMIT];
+
+	/* This test assumes TRACKER_FD_LIMIT is a multiple of 2. */
+	assert((TRACKER_FD_LIMIT % 2 == 0) && TRACKER_FD_LIMIT);
+
+        tracker = fd_tracker_create(TRACKER_FD_LIMIT);
+	assert(tracker);
+
+	ret = fd_tracker_open_unsuspendable_fd(tracker, fds,
+			NULL, TRACKER_FD_LIMIT, open_pipes, NULL);
+	ok(ret == 0, "File descriptor tracker allowed the user to meet its limit with unsuspendable file descritptors (%d)",
+			TRACKER_FD_LIMIT);
+
+	ret = fd_tracker_open_unsuspendable_fd(tracker, &out_fd,
+			NULL, 1, noop_open, &stdout_fd);
+	ok(ret == -EMFILE, "EMFILE reported when exceeding the file descriptor limit while opening an unsuspendable fd");
+
+	ret = fd_tracker_close_unsuspendable_fd(tracker,
+			fds, TRACKER_FD_LIMIT, close_pipes, NULL);
+	assert(!ret);
+
+	fd_tracker_destroy(tracker);
+}
+
+/*
+ * Validate that the tracker refuses to track two identical unsuspendable
+ * file descriptors.
+ */
+static
+void test_unsuspendable_close_untracked(void)
+{
+	int ret, stdout_fd = fileno(stdout), unknown_fds[2], out_fd;
+	struct fd_tracker *tracker;
+
+        tracker = fd_tracker_create(TRACKER_FD_LIMIT);
+	if (!tracker) {
+		return;
+	}
+
+	ret = pipe(unknown_fds);
+	assert(!ret);
+	assert(close(unknown_fds[0]) == 0);
+	assert(close(unknown_fds[1]) == 0);
+
+	ret = fd_tracker_open_unsuspendable_fd(tracker, &out_fd,
+			NULL, 1, noop_open, &stdout_fd);
+	assert(!ret);
+
+	ret = fd_tracker_close_unsuspendable_fd(tracker,
+			unknown_fds, 1, noop_close, NULL);
+	ok(ret == -EINVAL, "EINVAL reported on close of an untracked file descriptor");
+
+	ret = fd_tracker_close_unsuspendable_fd(tracker,
+			&stdout_fd, 1, noop_close, NULL);
+	assert(!ret);
+
+	fd_tracker_destroy(tracker);
+}
+
+static
+int open_files(struct fd_tracker *tracker, const char *dir, unsigned int count,
+		struct fs_handle **handles, char **file_paths)
+{
+	int ret = 0;
+	unsigned int i;
+
+	for (i = 0; i < count; i++) {
+		int ret;
+	        char *file_path;
+		struct fs_handle *handle;
+		mode_t mode = S_IWUSR | S_IRUSR;
+
+		ret = asprintf(&file_path, "%s/file-%u", dir, i);
+		assert(ret >= 0);
+	        file_paths[i] = file_path;
+
+		handle = fd_tracker_open_fs_handle(tracker, file_path,
+				O_RDWR | O_CREAT, &mode);
+		if (!handle) {
+			ret = -1;
+			break;
+		}
+		handles[i] = handle;
+	}
+	return ret;
+}
+
+static
+int cleanup_files(struct fd_tracker *tracker, const char *dir,
+		unsigned int count, struct fs_handle **handles,
+		char **file_paths)
+{
+	int ret = 0;
+	unsigned int i;
+
+	for (i = 0; i < count; i++) {
+		char *file_path = file_paths[i];
+
+		if (!file_path) {
+			break;
+		}
+		(void) unlink(file_path);
+		free(file_path);
+	        if (fs_handle_close(handles[i])) {
+			ret = -1;
+		}
+	}
+	return ret;
+}
+
+static
+void test_suspendable_limit(void)
+{
+	int ret;
+	const int files_to_create = TRACKER_FD_LIMIT * 10;
+	struct fd_tracker *tracker;
+	char tmp_path_pattern[] = TMP_DIR_PATTERN;
+	const char *output_dir;
+	char *output_files[files_to_create];
+	struct fs_handle *handles[files_to_create];
+
+	memset(output_files, 0, sizeof(output_files));
+	memset(handles, 0, sizeof(handles));
+
+        tracker = fd_tracker_create(TRACKER_FD_LIMIT);
+	if (!tracker) {
+		return;
+	}
+
+        output_dir = mkdtemp(tmp_path_pattern);
+	if (!output_dir) {
+		diag("Failed to create temporary path of the form %s",
+				TMP_DIR_PATTERN);
+		assert(0);
+	}
+
+	ret = open_files(tracker, output_dir, files_to_create, handles,
+			output_files);
+	ok(!ret, "Created %d files with a limit of %d simultaneously-opened file descriptor",
+			files_to_create, TRACKER_FD_LIMIT);
+	check_fd_count(TRACKER_FD_LIMIT + STDIO_FD_COUNT + unknown_fds_count);
+
+	ret = cleanup_files(tracker, output_dir, files_to_create, handles,
+			output_files);
+	ok(!ret, "Close all opened filesystem handles");
+	(void) rmdir(output_dir);
+	fd_tracker_destroy(tracker);
+}
+
+static
+void test_mixed_limit(void)
+{
+	int ret;
+	const int files_to_create = TRACKER_FD_LIMIT;
+	struct fd_tracker *tracker;
+	char tmp_path_pattern[] = TMP_DIR_PATTERN;
+	const char *output_dir;
+	char *output_files[files_to_create];
+	struct fs_handle *handles[files_to_create];
+
+	memset(output_files, 0, sizeof(output_files));
+	memset(handles, 0, sizeof(handles));
+
+        tracker = fd_tracker_create(TRACKER_FD_LIMIT);
+	if (!tracker) {
+		return;
+	}
+
+        output_dir = mkdtemp(tmp_path_pattern);
+	if (!output_dir) {
+		diag("Failed to create temporary path of the form %s",
+				TMP_DIR_PATTERN);
+		assert(0);
+	}
+
+	ret = open_files(tracker, output_dir, files_to_create, handles,
+			output_files);
+	ok(!ret, "Created %d files with a limit of %d simultaneously-opened file descriptor",
+			files_to_create, TRACKER_FD_LIMIT);
+	diag("Check file descriptor count after opening %u files", files_to_create);
+	check_fd_count(TRACKER_FD_LIMIT + STDIO_FD_COUNT + unknown_fds_count);
+
+	/*
+	 * Open unsuspendable fds (stdin, stdout, stderr) and verify that the fd
+	 * cap is still respected.
+	 */
+	diag("Check file descriptor count after adding %d unsuspendable fds",
+			STDIO_FD_COUNT);
+	track_std_fds(tracker);
+	check_fd_count(TRACKER_FD_LIMIT + unknown_fds_count);
+	diag("Untrack unsuspendable file descriptors");
+	untrack_std_fds(tracker);
+	check_fd_count(TRACKER_FD_LIMIT + unknown_fds_count);
+
+	ret = cleanup_files(tracker, output_dir, files_to_create, handles,
+			output_files);
+	ok(!ret, "Close all opened filesystem handles");
+	(void) rmdir(output_dir);
+	fd_tracker_destroy(tracker);
+}
+
+/*
+ * Open more files than allowed by the fd tracker's cap and write,
+ * byte-by-byte, and in round-robin, a string. The goal is to force
+ * the fd tracker to suspend and resume the fs_handles often and
+ * verify that the fd cap is always respected.
+ *
+ * The content of the files is also verified at the end.
+ */
+static
+void test_suspendable_restore(void)
+{
+	int ret;
+	const int files_to_create = TRACKER_FD_LIMIT * 10;
+	struct fd_tracker *tracker;
+	char tmp_path_pattern[] = TMP_DIR_PATTERN;
+	const char *output_dir;
+	char *output_files[files_to_create];
+	struct fs_handle *handles[files_to_create];
+	size_t content_index;
+	int handle_index;
+	bool write_success = true;
+	bool fd_cap_respected = true;
+	bool content_ok = true;
+
+	memset(output_files, 0, sizeof(output_files));
+	memset(handles, 0, sizeof(handles));
+
+        tracker = fd_tracker_create(TRACKER_FD_LIMIT);
+	if (!tracker) {
+		return;
+	}
+
+        output_dir = mkdtemp(tmp_path_pattern);
+	if (!output_dir) {
+		diag("Failed to create temporary path of the form %s",
+				TMP_DIR_PATTERN);
+		assert(0);
+	}
+
+	ret = open_files(tracker, output_dir, files_to_create, handles,
+			output_files);
+	ok(!ret, "Created %d files with a limit of %d simultaneously-opened file descriptor",
+			files_to_create, TRACKER_FD_LIMIT);
+	diag("Check file descriptor count after opening %u files", files_to_create);
+	check_fd_count(TRACKER_FD_LIMIT + STDIO_FD_COUNT + unknown_fds_count);
+
+	for (content_index = 0; content_index < sizeof(file_contents); content_index++) {
+		for (handle_index = 0; handle_index < files_to_create; handle_index++) {
+			int fd;
+			struct fs_handle *handle = handles[handle_index];
+			const char *path = output_files[handle_index];
+
+			fd = fs_handle_get_fd(handle);
+			if (fd < 0) {
+				write_success = false;
+			        diag("Failed to restore fs_handle to %s",
+					        path);
+				goto skip_write;
+			}
+
+			do {
+				ret = write(fd, file_contents + content_index, 1);
+			} while (ret < 0 && errno == EINTR);
+
+			if (ret != 1) {
+				write_success = false;
+			        PERROR("write() to %s failed", path);
+				goto skip_write;
+			}
+
+			if (fd_count() >
+					(TRACKER_FD_LIMIT + STDIO_FD_COUNT +
+					unknown_fds_count)) {
+				fd_cap_respected = false;
+			}
+
+		        fs_handle_put_fd(handle);
+		}
+	}
+skip_write:
+	ok(write_success, "Wrote reference string to %d files",
+			files_to_create);
+	ok(fd_cap_respected, "FD tracker enforced the file descriptor cap");
+
+	/* Validate the contents of the files. */
+	for (handle_index = 0; handle_index < files_to_create; handle_index++) {
+		struct stat fd_stat;
+		const char *path = output_files[handle_index];
+		char read_buf[sizeof(file_contents)];
+		char *read_pos;
+		size_t to_read = sizeof(read_buf);
+		int fd;
+
+		fd = open(path, O_RDONLY);
+		assert(fd >= 0);
+		ret = fstat(fd, &fd_stat);
+		assert(!ret);
+		if (fd_stat.st_size != sizeof(file_contents)) {
+			diag("Content size of file %s doesn't match, got %" PRId64 ", expected %zu",
+					path, (int64_t) fd_stat.st_size,
+					sizeof(file_contents));
+			content_ok = false;
+			(void) close(fd);
+			break;
+		}
+
+		read_pos = read_buf;
+		do {
+			ret = read(fd, read_pos, to_read);
+			if (ret > 0) {
+				to_read -= ret;
+				read_pos += ret;
+			}
+		} while (to_read && (ret < 0 && errno == EINTR));
+		if (ret < 0) {
+			content_ok = false;
+			PERROR("Failed to read file %s", path);
+			(void) close(fd);
+			break;
+		}
+
+		if (strcmp(file_contents, read_buf)) {
+			content_ok = false;
+			diag("File content doesn't match the expectated string");
+			(void) close(fd);
+			break;
+		}
+		(void) close(fd);
+	}
+	ok(content_ok, "Files contain the expected content");
+	ret = cleanup_files(tracker, output_dir, files_to_create, handles,
+			output_files);
+	ok(!ret, "Close all opened filesystem handles");
+	(void) rmdir(output_dir);
+	fd_tracker_destroy(tracker);	
+}
+
+int main(int argc, char **argv)
+{
+	plan_tests(NUM_TESTS);
+	diag("File descriptor tracker unit tests");
+
+	unknown_fds_count = fd_count() - STDIO_FD_COUNT;
+	assert(unknown_fds_count >= 0);
+
+	diag("Unsuspendable - basic");
+	test_unsuspendable_basic();
+	diag("Unsuspendable - callback return values");
+	test_unsuspendable_cb_return();
+	diag("Unsuspendable - duplicate file descriptors");
+	test_unsuspendable_duplicate();
+	diag("Unsuspendable - closing an untracked file descriptor");
+	test_unsuspendable_close_untracked();
+	diag("Unsuspendable - check that file descritptor limit is enforced");
+	test_unsuspendable_limit();
+
+	diag("Suspendable - check that file descritptor limit is enforced");
+	test_suspendable_limit();
+	diag("Suspendable - restoration test");
+	test_suspendable_restore();
+
+	diag("Mixed - check that file descritptor limit is enforced");
+	test_mixed_limit();
+
+	return exit_status();
+}

--- a/tests/unit/test_fd_tracker.c
+++ b/tests/unit/test_fd_tracker.c
@@ -30,6 +30,8 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
+#include <urcu.h>
+
 #include <common/fd-tracker/fd-tracker.h>
 #include <common/error.h>
 
@@ -635,6 +637,8 @@ int main(int argc, char **argv)
 	plan_tests(NUM_TESTS);
 	diag("File descriptor tracker unit tests");
 
+	rcu_register_thread();
+
 	unknown_fds_count = fd_count() - STDIO_FD_COUNT;
 	assert(unknown_fds_count >= 0);
 
@@ -657,5 +661,6 @@ int main(int argc, char **argv)
 	diag("Mixed - check that file descritptor limit is enforced");
 	test_mixed_limit();
 
+	rcu_unregister_thread();
 	return exit_status();
 }


### PR DESCRIPTION
Issue
=====
The fact that LTTng traces are stored as separate streams (per-core)
forces the relay daemon to keep a lot of file descriptors open.
Users that collect traces from a large number of targets (and consume
them from a live client) have repeatedly reported file descriptor
exhaustion issues.

Part of the problem lies in the high number of files that have to
be opened to store and read a given trace. However, this is a problem
that would happen (albeit not as frequently) if traces were stored in a
single file as the relay daemon can receive traces from many hosts,
and each host can be sending traces from separate sessions.

It was observed that users were often hitting this problem following
a connectivity problem since the connections, and thus all stream
files, are kept open until the TCP connections timeout. Meanwhile,
the targets, upon recovering from the network problem, would
reconnect and cause more files to be opened.

Under unreliable networking conditions, this causes the number
of consumed file descriptor to escalate quickly.

Solution
========
This PR adds an fd-tracker utility to the common libs.
This interface allows a process to keep track of its open
file descriptors and enforce a limit to the number of file
descriptors that may be simultaneously opened.

The fd-tracker defines two classes of file descriptors: suspendable
and unsuspendable file descriptors.

Suspendable file descriptors are handles to filesystem objects
(e.g. regular files) that may be closed and re-opened later without
affecting the application.

A suspendable file descriptor can be opened by creating a filesystem
handle (fs_handle) using the fd-tracker. The raw file descriptor
must then be obtained and released using that handle. Closing the
handle will effectively ensure that the file descritptor is closed.

Unsuspendable file descriptors are file descriptors that cannot
be closed without affecting the application's state. For instance,
it is not possible to close and re-open a pipe, a TCP socket, or
an epoll fd without involving some app-specific logic. Thus, the
fd-tracker considers those file descriptors as unsuspendable.

Opening an unsuspendable file descritptor will return a raw file
decriptor to the application. It is its responsability to notify the
fd-tracker of the file descriptor's closing to ensure the number
of active file descriptors can be tracked accurately.

If a request to open a new file descriptors is made to the fd-tracker
and the process has already reached its maximal count of
simultaneously opened file descriptors, an attempt will be made to
suspend a suspendable file descriptor and release a slot.

Suspending a file descriptor involves:
  - verifying that the file is still available on the FS (restorable),
  - sampling its current position,
  - closing the file descriptor.

Note that suspending a file descriptor eliminates POSIX's guarantee
that a file may be unlinked at any time without affecting the
application (provided that it holds an open FD to that
file). Applications using the fd-tracker that need to maintain this
guarantee should open those files as unsuspendable file descriptors.

To protect against unlinking and file replacement scenarios, the
fd-tracker samples the files' inode number when a fs_handle is
created. This inode number will then be checked anytime the handle
is suspended or restored to ensure that the application is made
aware of the file's unavailability. This is preferable to
inadvertently opening another file of the same name if the original
file was unlinked and/or replaced between a fs_handle's suspension
and restoration.

The allowed number of simultaneously active file descriptors can
be controlled using the relay daemon's `--fd-pool-size` option.

Known drawbacks
===============

Performance
-----------------
Performance degradation may occur if the LRU cache policy proves
to be unsuitable or if the number of simultaneously active file descriptors
is limited to an unreasonably low value. The `fd_tracker_log()` function
can be used to periodically monitor (or once, on close) the fd cache's
hit rate and content.


Unlinking/deleting files
-----------------------------
As previously mentioned, the use of suspendable filesystem handles
makes it tricky to deal with unlinking files. In the case of the relay daemon,
it is not obvious that it is a problem to not allow users to delete or
overwrite traces that are being received/consumed.

Since the relay daemon can unlink files that are being consumed by a
live client (e.g. when a limit of tracefiles was imposed on the session),
the fd-tracker uses an internal lttng-inode to represent files opened
through a filesystem handle. When a filesystem handle is unlinked, the
file is renamed to contain a `-deleted` suffix. When the last filesystem
handle refering to this file is released, the actual `unlink()` is performed.

Note that this way of handling unlinked files is similar to what `NFS`
does.


Stability
----------
There are error paths that do not properly recover when a file cannot be
restored. In essence, the paths that perform reads or writes on files can
now fail for this reason. This is not a new issue as those code paths
were already buggy as they should properly recover from read/write
failures.

This can be observed by setting the `--fd-pool-size` option to a small
value and using many unsuspendable fds (i.e. by opening many
connections) up until the daemon fails to restore a single fs_handle.

I am considering reserving a number of slots for fs_handles so that
every thread can hold at least one active fs_handle.
