### PR TITLE
Prevent channel buffer allocation larger than memory

### DIFF
--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -61,5 +61,7 @@ int utils_create_lock_file(const char *filepath);
 int utils_recursive_rmdir(const char *path);
 int utils_truncate_stream_file(int fd, off_t length);
 int utils_show_help(int section, const char *page_name, const char *help_msg);
+size_t utils_get_memory_available(void);
+size_t utils_get_memory_total(void);
 
 #endif /* _COMMON_UTILS_H */

--- a/tests/regression/kernel/test_channel
+++ b/tests/regression/kernel/test_channel
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# Copyright (C) - 2018 Francis Deslauriers <francis.deslauriers@efficios.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License, version 2 only, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+TEST_DESC="Kernel tracer - Channel configuration"
+
+CURDIR=$(dirname $0)/
+TESTDIR=$CURDIR/../..
+NUM_TESTS=8
+
+source $TESTDIR/utils/utils.sh
+
+function test_channel_buffer()
+{
+	TRACE_PATH=$(mktemp -d)
+	SESSION_NAME="test_session_name"
+	CHANNEL_NAME="test_channel_name"
+	create_lttng_session_ok "$SESSION_NAME" "$TRACE_PATH"
+
+	# Try to create a tiny buffer.
+	lttng_enable_kernel_channel_ok "$SESSION_NAME" "$CHANNEL_NAME" --subbuf-size=4k --num-subbuf=1
+
+	destroy_lttng_session_ok "$SESSION_NAME"
+
+	rm -rf "$TRACE_PATH"
+}
+
+function test_channel_buffer_too_large()
+{
+	TRACE_PATH=$(mktemp -d)
+	SESSION_NAME="test_session_name"
+	CHANNEL_NAME="test_channel_name"
+	create_lttng_session_ok "$SESSION_NAME" "$TRACE_PATH"
+
+	# Try to create a buffer larger than memory. This testcase will need to
+	# be ajusted if someone has a computer with 1024*1000Go of ram.
+	lttng_enable_kernel_channel_fail "$SESSION_NAME" "$CHANNEL_NAME" --subbuf-size=1000G --num-subbuf=1024
+
+	destroy_lttng_session_ok "$SESSION_NAME"
+
+	rm -rf "$TRACE_PATH"
+}
+
+plan_tests $NUM_TESTS
+print_test_banner "$TEST_DESC"
+
+if [ "$(id -u)" == "0" ]; then
+	isroot=1
+else
+	isroot=0
+fi
+
+skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
+{
+	start_lttng_sessiond
+
+	test_channel_buffer
+	test_channel_buffer_too_large
+
+	stop_lttng_sessiond
+}

--- a/tests/root_regression
+++ b/tests/root_regression
@@ -1,4 +1,5 @@
 regression/kernel/test_all_events
+regression/kernel/test_channel
 regression/kernel/test_event_basic
 regression/kernel/test_syscall
 regression/kernel/test_clock_override


### PR DESCRIPTION
Background
==========
Until recently (lttng-modules commit 1f0ab1e) it was possible to trigger
an Out-Of-Memory crash by creating a kernel channel buffer larger than
the currently usable memory on the system. The following commands was
triggering the issue on my laptop:
  lttng create
  lttng enable-channel -k --subbuf-size=100G --num-subbuf=1 chan0

The lttng-modules commit 1f0ab1e adds a verification based on an
estimate to prevent this from happening. Since this kernel tracer sanity
check is based on an estimate, it would safer to do a similar check on
the session daemon side.

Approach
========
Use the `/proc/meminfo` procfile to get an estimate of the current size
of available memory (using `MemAvailable`). The `MemAvailable` field was
added in the Linux kernel 3.14, so if it's absent we fallback to
verifying that the requested buffer is smaller than the physical memory
on the system.

Side effect
===========
This patch has the interesting side effect to alerting the user with an
error that buffer allocation has failed because of memory availability
in both --kernel and --userspace channel creation.

Drawback
========
The fallback check on older kernels is imperfect and is only to prevent
obvious user errors.

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>