### PR TITLE
Fix: compile fails for x32 arch

### DIFF
--- a/src/bin/lttng/utils.c
+++ b/src/bin/lttng/utils.c
@@ -158,7 +158,7 @@ unsigned int fls_u32(uint32_t x)
 #define HAS_FLS_U32
 #endif
 
-#if defined(__x86_64)
+#if defined(__x86_64) && !defined(__ILP32__)
 static inline
 unsigned int fls_u64(uint64_t x)
 {

--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -1223,7 +1223,7 @@ static inline unsigned int fls_u32(uint32_t x)
 #define HAS_FLS_U32
 #endif
 
-#if defined(__x86_64)
+#if defined(__x86_64) && !defined(__ILP32__)
 static inline
 unsigned int fls_u64(uint64_t x)
 {


### PR DESCRIPTION
It fails to compile for x32 arch:

| .../src/common/utils.c: Assembler messages:
| .../src/common/utils.c:1026: Error: register type mismatch for `bsr'
| .../src/common/utils.c:1028: Error: operand type mismatch for `movq'

Add macro check that not to define that fls_u64() for x32.

Signed-off-by: Kai Kang <kai.kang@windriver.com>