### PR TITLE
doc: Add reference to USDT probes

### DIFF
--- a/doc/man/lttng-enable-event.1.txt
+++ b/doc/man/lttng-enable-event.1.txt
@@ -410,10 +410,10 @@ Dynamic user space probes
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 With the option:--userspace-probe option, you can instrument function
 entries of any user space binary (application or library) using either
-an available symbol name or a SystemTap Statically Defined Tracepoint
-(SDT, a DTrace-style marker) probe's provider and probe names. As of
-this version, only SDT probes that are :not: surrounded by a reference
-counter (semaphore) are supported.
+an available symbol name or a SystemTap User-level Statically Defined
+Tracing (USDT, a DTrace-style marker) probe's provider and probe names.
+As of this version, only USDT probes that are :not: surrounded by a
+reference counter (semaphore) are supported.
 
 The option:--userspace-probe option must be specified with the
 option:--kernel option because it uses Linux's uprobe feature to
@@ -519,7 +519,7 @@ Examples:
 * `--userspace-probe=httpd:ap_run_open_htaccess`
 
 ++sdt:++__PATH__++:++__PROVIDER__++:++__NAME__::
-    Dynamically instrument an SDT probe within a user space application
+    Dynamically instrument a USDT probe within a user space application
     or library.
 +
 --
@@ -534,9 +534,9 @@ This can be:
   `PATH` environment variable.
 
 __PROVIDER__++:++__NAME__::
-    SDT provider and probe names.
+    USDT provider and probe names.
 +
-For example, with the following SDT probe:
+For example, with the following USDT probe:
 +
 [source,c]
 ----


### PR DESCRIPTION
SDT probes are known by most as USDT probes. People may be looking for them
by that name.

Signed-off-by: Geneviève Bastien <gbastien+lttng@versatic.net>