### PR TITLE
Add lttng-module's kallsyms probe module

### DIFF
--- a/src/bin/lttng-sessiond/modprobe.c
+++ b/src/bin/lttng-sessiond/modprobe.c
@@ -62,6 +62,7 @@ struct kern_modules_param kern_modules_probes_default[] = {
 	{ "lttng-probe-irq" },
 	{ "lttng-probe-jbd" },
 	{ "lttng-probe-jbd2" },
+	{ "lttng-probe-kallsyms" },
 	{ "lttng-probe-kmem" },
 	{ "lttng-probe-kvm" },
 	{ "lttng-probe-kvm-x86" },


### PR DESCRIPTION
This adds the lttng-probe-kallsyms kernel module to the kernel modules to load when the session daemon starts.

Signed-off-by: Geneviève Bastien <gbastien@versatic.net>