### PR TITLE
Fix: namespace our gettid wrapper

### DIFF
--- a/src/common/compat/tid.h
+++ b/src/common/compat/tid.h
@@ -29,11 +29,9 @@
 #include <syscall.h>
 #endif
 
-#if defined(_syscall0)
-_syscall0(pid_t, gettid)
-#elif defined(__NR_gettid)
+#if defined(__NR_gettid)
 #include <unistd.h>
-static inline pid_t gettid(void)
+static inline pid_t lttng_gettid(void)
 {
 	return syscall(__NR_gettid);
 }
@@ -42,7 +40,7 @@ static inline pid_t gettid(void)
 #include <unistd.h>
 
 /* Fall-back on getpid for tid if not available. */
-static inline pid_t gettid(void)
+static inline pid_t lttng_gettid(void)
 {
 	return getpid();
 }

--- a/src/common/error.h
+++ b/src/common/error.h
@@ -151,11 +151,11 @@ static inline void __lttng_print_check_abort(enum lttng_error_level type)
 /* Three level of debug. Use -v, -vv or -vvv for the levels */
 #define _ERRMSG(msg, type, fmt, args...) __lttng_print(type, msg \
 		" - %s [%ld/%ld]: " fmt " (in %s() at " __FILE__ ":" XSTR(__LINE__) ")\n", \
-			log_add_time(), (long) getpid(), (long) gettid(), ## args, __func__)
+			log_add_time(), (long) getpid(), (long) lttng_gettid(), ## args, __func__)
 
 #define _ERRMSG_NO_LOC(msg, type, fmt, args...) __lttng_print(type, msg	\
 		" - %s [%ld/%ld]: " fmt "\n", \
-			log_add_time(), (long) getpid(), (long) gettid(), ## args)
+			log_add_time(), (long) getpid(), (long) lttng_gettid(), ## args)
 
 #define MSG(fmt, args...) \
 	__lttng_print(PRINT_MSG, fmt "\n", ## args)


### PR DESCRIPTION
Since glibc 2.30, a gettid wrapper was added that conflicts with the
static declaration. Namespace the wrapper so there is no conflict.

Fixes:
 - http://autobuild.buildroot.org/results/8680c5a355b226cf978397615cbe5df1c5f8c656

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>