### PR TITLE
Tests: Fix: Segfault in `test_utils_expand_path()`

### DIFF
--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -379,6 +379,9 @@ char *_utils_expand_path(const char *path, bool keep_symlink)
 		/* Resolve partially our path */
 		absolute_path = utils_partial_realpath(absolute_path,
 				absolute_path, LTTNG_PATH_MAX);
+		if (!absolute_path) {
+			goto error;
+		}
 	}
 
 	ret = expand_double_slashes_dot_and_dotdot(absolute_path);


### PR DESCRIPTION
Background
==========
I have a file named "/a" on my file system (don't ask why).

Issue
=====
While running the `test_utils_expand_path` test case on my machine, I
get a Segfault. Here is the gdb backtrace:

  #0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:62
  #1  0x0000555555559eb7 in expand_double_slashes_dot_and_dotdot (path=0x0) at utils.c:223
  #2  0x000055555555a2d8 in _utils_expand_path (path=0x55555556b250 "/a/b/c/d/e", keep_symlink=true) at utils.c:384
  #3  0x000055555555a408 in utils_expand_path (path=0x55555556b250 "/a/b/c/d/e") at utils.c:423
  #4  0x000055555555859e in test_utils_expand_path () at test_utils_expand_path.c:291
  #5  0x00005555555589b0 in main (argc=1, argv=0x7fffffffe5e8) at test_utils_expand_path.c:352

I get this backtrace because the function `utils_partial_realpath()`
returns NULL when it tries to expand the "/a/b/c/d/e" path and realize
that it could not exist since "/a" is a file and not a directory.

Anyways, the returned NULL pointer is ignored and directly used in the
`expand_double_slashes_dot_and_dotdot()` function right after.

This configuration ("/a" being a file) is expected to fail but not to segfault.
It could be reproduce in a real scenario when creating directory
structures.

Solution
========
Return an error if `utils_partial_realpath()` returns NULL.

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>