### PR TITLE
Fix: lttng-elf.c: dereferencing pointer before null check

### DIFF
--- a/src/common/lttng-elf.c
+++ b/src/common/lttng-elf.c
@@ -646,12 +646,13 @@ char *lttng_elf_get_section_data(struct lttng_elf *elf,
 	int ret;
 	off_t section_offset;
 	char *data;
-	const size_t max_alloc_size = min_t(size_t, MAX_SECTION_DATA_SIZE,
-			elf->file_size);
+	size_t max_alloc_size;
 
 	if (!elf || !shdr) {
 		goto error;
 	}
+
+	max_alloc_size = min_t(size_t, MAX_SECTION_DATA_SIZE, elf->file_size);
 
 	section_offset = shdr->sh_offset;
 	if (lseek(elf->fd, section_offset, SEEK_SET) < 0) {


### PR DESCRIPTION
Coverity report:
  CID 1405899 (#1 of 1): Dereference before null check (REVERSE_INULL)
  check_after_deref: Null-checking elf suggests that it may be null, but it has
  already been dereferenced on all paths leading to the check.

Reported-by: Coverity (1405899) Dereference before null check
Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>