### PR TITLE
Slibtool build fixes

### DIFF
--- a/src/bin/lttng-sessiond/Makefile.am
+++ b/src/bin/lttng-sessiond/Makefile.am
@@ -7,9 +7,9 @@ if EMBED_HELP
 AM_CPPFLAGS += -I$(top_builddir)/doc/man
 endif
 
-bin_PROGRAMS = lttng-sessiond
+noinst_LTLIBRARIES = liblttng-sessiond-common.la
 
-lttng_sessiond_SOURCES = utils.c utils.h \
+liblttng_sessiond_common_la_SOURCES = utils.c utils.h \
                        trace-kernel.c trace-kernel.h \
                        kernel.c kernel.h \
                        ust-app.h ust-sigbus.h trace-ust.h notify-apps.h \
@@ -59,21 +59,16 @@ lttng_sessiond_SOURCES = utils.c utils.h \
                        action-executor.c action-executor.h\
                        trigger-error-query.c
 
-lttng_sessiond_LDFLAGS = -rdynamic
-
 if HAVE_LIBLTTNG_UST_CTL
-lttng_sessiond_SOURCES += trace-ust.c ust-registry.c ust-app.c \
+liblttng_sessiond_common_la_SOURCES += trace-ust.c ust-registry.c ust-app.c \
 			ust-consumer.c ust-consumer.h notify-apps.c \
 			ust-metadata.c ust-clock.h agent-thread.c agent-thread.h \
 			ust-field-utils.h ust-field-utils.c \
 			ust-sigbus.c
 endif
 
-# Add main.c at the end for compile order
-lttng_sessiond_SOURCES += lttng-sessiond.h main.c
-
 # link on liblttngctl for check if sessiond is already alive.
-lttng_sessiond_LDADD = -lurcu-common $(URCU_LIBS) $(KMOD_LIBS) \
+liblttng_sessiond_common_la_LIBADD = $(URCU_LIBS) $(KMOD_LIBS) \
 		$(top_builddir)/src/lib/lttng-ctl/liblttng-ctl.la \
 		$(top_builddir)/src/common/sessiond-comm/libsessiond-comm.la \
 		$(top_builddir)/src/common/kernel-ctl/libkernel-ctl.la \
@@ -88,5 +83,13 @@ lttng_sessiond_LDADD = -lurcu-common $(URCU_LIBS) $(KMOD_LIBS) \
 
 
 if HAVE_LIBLTTNG_UST_CTL
-lttng_sessiond_LDADD += $(UST_CTL_LIBS)
+liblttng_sessiond_common_la_LIBADD += $(UST_CTL_LIBS)
 endif
+
+bin_PROGRAMS = lttng-sessiond
+
+lttng_sessiond_SOURCES = lttng-sessiond.h main.c
+
+lttng_sessiond_LDFLAGS = -rdynamic
+
+lttng_sessiond_LDADD = liblttng-sessiond-common.la

--- a/tests/regression/tools/live/Makefile.am
+++ b/tests/regression/tools/live/Makefile.am
@@ -10,11 +10,7 @@ LIBHASHTABLE=$(top_builddir)/src/common/hashtable/libhashtable.la
 LIBRELAYD=$(top_builddir)/src/common/relayd/librelayd.la
 LIBHEALTH=$(top_builddir)/src/common/health/libhealth.la
 LIBCOMPAT=$(top_builddir)/src/common/compat/libcompat.la
-
-LIVE= $(top_builddir)/src/bin/lttng-sessiond/consumer.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/globals.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/utils.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/snapshot.$(OBJEXT)
+LIBLTTNG_SESSIOND_COMMON=$(top_builddir)/src/bin/lttng-sessiond/liblttng-sessiond-common.la
 
 noinst_PROGRAMS = live_test
 EXTRA_DIST = test_kernel test_lttng_kernel
@@ -24,10 +20,7 @@ EXTRA_DIST += test_ust test_ust_tracefile_count test_lttng_ust
 endif
 
 live_test_SOURCES = live_test.c
-live_test_LDADD = $(LIBTAP) $(LIBCOMMON) $(LIBRELAYD) $(LIBSESSIOND_COMM) \
-		$(LIBHASHTABLE) $(LIBHEALTH) $(DL_LIBS) $(LIBCOMPAT) -lrt
-live_test_LDADD += $(LIVE) \
-		$(top_builddir)/src/lib/lttng-ctl/liblttng-ctl.la
+live_test_LDADD = $(LIBTAP) $(LIBLTTNG_SESSIOND_COMMON) $(DL_LIBS)
 
 all-local:
 	@if [ x"$(srcdir)" != x"$(builddir)" ]; then \

--- a/tests/regression/tools/live/live_test.c
+++ b/tests/regression/tools/live/live_test.c
@@ -23,6 +23,7 @@
 
 #include <tap/tap.h>
 #include <lttng/lttng.h>
+#include <lttng/ust-sigbus.h>
 
 #include <urcu/list.h>
 #include <common/common.h>
@@ -40,6 +41,8 @@
 /* Number of TAP tests in this file */
 #define NUM_TESTS 11
 #define mmap_size 524288
+
+DEFINE_LTTNG_UST_SIGBUS_STATE();
 
 static int control_sock;
 struct live_session *session;

--- a/tests/regression/ust/clock-override/Makefile.am
+++ b/tests/regression/ust/clock-override/Makefile.am
@@ -17,7 +17,7 @@ GETCPU_LIBTOOL_FLAGS = \
     -module \
     -shared \
     -avoid-version \
-    --no-as-needed \
+    -Wl,--no-as-needed \
     -rpath $(abs_builddir)
 
 noinst_LTLIBRARIES = lttng-ust-clock-override-test.la

--- a/tests/regression/ust/getcpu-override/Makefile.am
+++ b/tests/regression/ust/getcpu-override/Makefile.am
@@ -18,7 +18,7 @@ GETCPU_LIBTOOL_FLAGS = \
     -module \
     -shared \
     -avoid-version \
-    --no-as-needed \
+    -Wl,--no-as-needed \
     -rpath $(abs_builddir)
 
 noinst_LTLIBRARIES = lttng-ust-getcpu-override-test.la

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -43,6 +43,7 @@ LIBSESSIOND_COMM=$(top_builddir)/src/common/sessiond-comm/libsessiond-comm.la
 LIBHASHTABLE=$(top_builddir)/src/common/hashtable/libhashtable.la
 LIBRELAYD=$(top_builddir)/src/common/relayd/librelayd.la
 LIBLTTNG_CTL=$(top_builddir)/src/lib/lttng-ctl/liblttng-ctl.la
+LIBLTTNG_SESSIOND_COMMON=$(top_builddir)/src/bin/lttng-sessiond/liblttng-sessiond-common.la
 
 # Define test programs
 noinst_PROGRAMS = \
@@ -170,21 +171,8 @@ test_ust_data_LDADD = $(LIBTAP) $(LIBCOMMON) $(LIBRELAYD) $(LIBSESSIOND_COMM) \
 test_ust_data_LDADD += $(SESSIOND_OBJS)
 endif
 
-# Kernel data structures unit test
-KERN_DATA_TRACE=$(top_builddir)/src/bin/lttng-sessiond/trace-kernel.$(OBJEXT) \
-		$(top_builddir)/src/common/compat/libcompat.la \
-		$(top_builddir)/src/bin/lttng-sessiond/consumer.$(OBJEXT) \
-		$(top_builddir)/src/bin/lttng-sessiond/globals.$(OBJEXT) \
-		$(top_builddir)/src/bin/lttng-sessiond/utils.$(OBJEXT) \
-		$(top_builddir)/src/bin/lttng-sessiond/tracker.$(OBJEXT) \
-		$(top_builddir)/src/common/health/libhealth.la \
-		$(top_builddir)/src/bin/lttng-sessiond/notification-thread-commands.$(OBJEXT) \
-		$(LIBLTTNG_CTL)
-
 test_kernel_data_SOURCES = test_kernel_data.c
-test_kernel_data_LDADD = $(LIBTAP) $(LIBCOMMON) $(LIBRELAYD) $(LIBSESSIOND_COMM) \
-			 $(LIBHASHTABLE) $(DL_LIBS) -lrt
-test_kernel_data_LDADD += $(KERN_DATA_TRACE)
+test_kernel_data_LDADD = $(LIBTAP) $(LIBLTTNG_SESSIOND_COMMON) $(DL_LIBS)
 
 # utils suffix for unit test
 

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -81,73 +81,10 @@ endif
 test_uri_SOURCES = test_uri.c
 test_uri_LDADD = $(LIBTAP) $(LIBCOMMON) $(LIBHASHTABLE) $(DL_LIBS)
 
-# Sessiond objects
-SESSIOND_OBJS = $(top_builddir)/src/bin/lttng-sessiond/buffer-registry.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/cmd.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/condition-internal.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/save.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/notification-thread-commands.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/kernel.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/ht-cleanup.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/notification-thread.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/action-executor.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/lttng-syscall.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/channel.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/agent.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/kernel-consumer.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/trace-kernel.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/rotation-thread.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/context.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/consumer.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/utils.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/fd-limit.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/notification-thread-events.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/event.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/event-notifier-error-accounting.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/timer.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/snapshot.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/sessiond-config.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/rotate.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/modprobe.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/session.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/globals.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/thread-utils.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/process-utils.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/thread.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/tracker.$(OBJEXT) \
-	 $(top_builddir)/src/bin/lttng-sessiond/trigger-error-query.$(OBJEXT) \
-	 $(top_builddir)/src/common/libcommon.la \
-	 $(top_builddir)/src/common/testpoint/libtestpoint.la \
-	 $(top_builddir)/src/common/compat/libcompat.la \
-	 $(top_builddir)/src/common/health/libhealth.la \
-	 $(top_builddir)/src/common/sessiond-comm/libsessiond-comm.la
-
-if HAVE_LIBLTTNG_UST_CTL
-SESSIOND_OBJS += $(top_builddir)/src/bin/lttng-sessiond/trace-ust.$(OBJEXT) \
-		 $(top_builddir)/src/bin/lttng-sessiond/ust-registry.$(OBJEXT) \
-		 $(top_builddir)/src/bin/lttng-sessiond/ust-app.$(OBJEXT) \
-		 $(top_builddir)/src/bin/lttng-sessiond/ust-consumer.$(OBJEXT) \
-		 $(top_builddir)/src/bin/lttng-sessiond/notify-apps.$(OBJEXT) \
-		 $(top_builddir)/src/bin/lttng-sessiond/ust-metadata.$(OBJEXT) \
-		 $(top_builddir)/src/bin/lttng-sessiond/agent-thread.$(OBJEXT) \
-		 $(top_builddir)/src/bin/lttng-sessiond/ust-field-utils.$(OBJEXT)
-endif
-
 RELAYD_OBJS = $(top_builddir)/src/bin/lttng-relayd/backward-compatibility-group-by.$(OBJEXT)
 
 test_session_SOURCES = test_session.c
-test_session_LDADD = $(LIBTAP) $(LIBCOMMON) $(LIBRELAYD) $(LIBSESSIOND_COMM) \
-		     $(LIBHASHTABLE) $(DL_LIBS) -lrt $(URCU_LIBS) \
-		     $(KMOD_LIBS) \
-		     $(top_builddir)/src/lib/lttng-ctl/liblttng-ctl.la \
-		     $(top_builddir)/src/common/kernel-ctl/libkernel-ctl.la \
-		     $(top_builddir)/src/common/compat/libcompat.la \
-		     $(top_builddir)/src/common/testpoint/libtestpoint.la \
-		     $(top_builddir)/src/common/health/libhealth.la \
-		     $(top_builddir)/src/common/config/libconfig.la \
-		     $(top_builddir)/src/common/string-utils/libstring-utils.la
-
-test_session_LDADD += $(SESSIOND_OBJS)
+test_session_LDADD = $(LIBTAP) $(LIBLTTNG_SESSIOND_COMMON) $(DL_LIBS)
 
 if HAVE_LIBLTTNG_UST_CTL
 test_session_SOURCES += ust-sigbus.c
@@ -157,18 +94,7 @@ endif
 # UST data structures unit test
 if HAVE_LIBLTTNG_UST_CTL
 test_ust_data_SOURCES = test_ust_data.c
-test_ust_data_LDADD = $(LIBTAP) $(LIBCOMMON) $(LIBRELAYD) $(LIBSESSIOND_COMM) \
-		      $(LIBHASHTABLE) $(DL_LIBS) -lrt $(URCU_LIBS) \
-		      $(UST_CTL_LIBS) \
-		      $(KMOD_LIBS) \
-		      $(top_builddir)/src/lib/lttng-ctl/liblttng-ctl.la \
-		      $(top_builddir)/src/common/kernel-ctl/libkernel-ctl.la \
-		      $(top_builddir)/src/common/compat/libcompat.la \
-		      $(top_builddir)/src/common/testpoint/libtestpoint.la \
-		      $(top_builddir)/src/common/health/libhealth.la \
-		      $(top_builddir)/src/common/config/libconfig.la \
-		      $(top_builddir)/src/common/string-utils/libstring-utils.la
-test_ust_data_LDADD += $(SESSIOND_OBJS)
+test_ust_data_LDADD = $(LIBTAP) $(LIBLTTNG_SESSIOND_COMMON) $(DL_LIBS)
 endif
 
 test_kernel_data_SOURCES = test_kernel_data.c

--- a/tests/unit/test_kernel_data.c
+++ b/tests/unit/test_kernel_data.c
@@ -15,6 +15,7 @@
 #include <common/compat/errno.h>
 #include <bin/lttng-sessiond/trace-kernel.h>
 #include <common/defaults.h>
+#include <lttng/ust-sigbus.h>
 
 #include <tap/tap.h>
 
@@ -22,6 +23,8 @@
 
 /* Number of TAP tests in this file */
 #define NUM_TESTS 11
+
+DEFINE_LTTNG_UST_SIGBUS_STATE();
 
 static const char alphanum[] =
 	"0123456789"

--- a/tests/unit/test_kernel_data.c
+++ b/tests/unit/test_kernel_data.c
@@ -23,11 +23,6 @@
 /* Number of TAP tests in this file */
 #define NUM_TESTS 11
 
-/* For error.h */
-int lttng_opt_quiet = 1;
-int lttng_opt_verbose;
-int lttng_opt_mi;
-
 static const char alphanum[] =
 	"0123456789"
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/tests/unit/test_session.c
+++ b/tests/unit/test_session.c
@@ -35,11 +35,6 @@
 
 static struct ltt_session_list *session_list;
 
-/* For error.h */
-int lttng_opt_quiet = 1;
-int lttng_opt_verbose = 0;
-int lttng_opt_mi;
-
 static const char alphanum[] =
 	"0123456789"
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZ"

--- a/tests/unit/test_ust_data.c
+++ b/tests/unit/test_ust_data.c
@@ -35,11 +35,6 @@
 
 DEFINE_LTTNG_UST_SIGBUS_STATE();
 
-/* For error.h */
-int lttng_opt_quiet = 1;
-int lttng_opt_verbose;
-int lttng_opt_mi;
-
 static const char alphanum[] =
 	"0123456789"
 	"ABCDEFGHIJKLMNOPQRSTUVWXYZ"


### PR DESCRIPTION
When building lttng-tools with slibtool (https://dev.midipix.org/cross/slibtool) it fails in many places.

* Many of the tests in `tests/unit/` fail with undefined references because they depend on functions compiled into programs and then are linked directly with the `.o` object files. Build projects that use `$(LIBTOOL)` should not link the object files themselves and should use `.la` libtool archives instead. So I created the `liblttng-sessiond-comm.la` convenience library that will be linked with instead.
* GNU libtool will silently ignore arguments it does not understand in many cases while slibtool will print an error which happens with `--no-as-needed` which is a linker argument. To solve this it needs to be passed directly to the linker with `-Wl,--no-as-needed`.

NOTE:

* Each individual commit will still work with GNU libtool.
* This does not solve all of the slibtool issues, the next one may need resolution in slibtool itself and I am making this PR now to avoid having to rebase the work later. Additionally these commits offer general improvements which remove hacks and reduce overlinking.

For reference the next slibtool build failure I see is:
```
Making install in baddr-statedump
make[4]: Entering directory '/tmp/lttng-tools/tests/regression/ust/baddr-statedump'
objcopy --only-keep-debug prog prog.debug
objcopy: prog: file format not recognized
make[4]: *** [Makefile:810: prog.debug] Error 1
make[4]: Leaving directory '/tmp/lttng-tools/tests/regression/ust/baddr-statedump'
make[3]: *** [Makefile:569: install-recursive] Error 1
make[3]: Leaving directory '/tmp/lttng-tools/tests/regression/ust'
make[2]: *** [Makefile:831: install-recursive] Error 1
make[2]: Leaving directory '/tmp/lttng-tools/tests/regression'
make[1]: *** [Makefile:557: install-recursive] Error 1
make[1]: Leaving directory '/tmp/lttng-tools/tests'
make: *** [Makefile:656: install-recursive] Error 1
```
This happens because slibtool places compiled binaries in the `.libs` directory while `prog` is a shell wrapper script. Ideally some method of `--mode=execute` could be used to solve this, but may require further work in slibtool itself to work. I will follow up on this PR in the future.