### PR TITLE
Update asciidoc url

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -144,7 +144,7 @@ You need the following tools to build {lt}:
 
 To build the {lt} manual pages:
 
-* **https://www.methods.co.nz/asciidoc/[AsciiDoc]{nbsp}≥{nbsp}8.4.5**
+* **https://asciidoc.org/[AsciiDoc]{nbsp}≥{nbsp}8.4.5**
 +
 NOTE: Previous versions could work, but were not tested.
 

--- a/doc/man/README.md
+++ b/doc/man/README.md
@@ -4,7 +4,7 @@ LTTng-tools man pages
 This directory contains the sources of the LTTng-tools man pages.
 
 LTTng-tools man pages are written in
-[AsciiDoc](http://www.methods.co.nz/asciidoc/), and then converted to
+[AsciiDoc](https://asciidoc.org/), and then converted to
 DocBook (XML) using the `asciidoc` command, and finally to troff using
 the appropriate DocBook XSL stylesheet (using the `xmlto` command).
 


### PR DESCRIPTION
Hey,

The url for AsciiDoc was no longer valid, this PR fixes it.

Same change as in: https://github.com/lttng/lttng-docs/pull/42