### PR TITLE
Tests: Add flags to test lttng userspace only

### DIFF
--- a/tests/destructive/metadata-regeneration
+++ b/tests/destructive/metadata-regeneration
@@ -202,6 +202,7 @@ if ! destructive_tests_enabled ; then
 	exit 0
 fi
 
+skip $SKIP_KERNEL_TEST -ne 0 "SKIP_KERNEL_TEST was enabled. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	original_date=$(date)

--- a/tests/perf/test_perf_raw.in
+++ b/tests/perf/test_perf_raw.in
@@ -154,6 +154,7 @@ have_libpfm
 
 test_ust_raw
 
+skip $SKIP_KERNEL_TEST -ne 0 "SKIP_KERNEL_TEST was enabled, skipping." 9 ||
 skip $isroot "Root access is needed for kernel testing, skipping." 9 ||
 {
 	modprobe lttng-test

--- a/tests/regression/kernel/test_all_events
+++ b/tests/regression/kernel/test_all_events
@@ -49,6 +49,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_callstack
+++ b/tests/regression/kernel/test_callstack
@@ -142,6 +142,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all tests." "$NUM_TESTS" ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_channel
+++ b/tests/regression/kernel/test_channel
@@ -53,6 +53,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	start_lttng_sessiond

--- a/tests/regression/kernel/test_clock_override
+++ b/tests/regression/kernel/test_clock_override
@@ -180,6 +180,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+	skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+	exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_event_basic
+++ b/tests/regression/kernel/test_event_basic
@@ -79,6 +79,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_kernel_function
+++ b/tests/regression/kernel/test_kernel_function
@@ -49,6 +49,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+	skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+	exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	start_lttng_sessiond_notap

--- a/tests/regression/kernel/test_lttng_logger
+++ b/tests/regression/kernel/test_lttng_logger
@@ -116,6 +116,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_ns_contexts
+++ b/tests/regression/kernel/test_ns_contexts
@@ -115,6 +115,10 @@ fi
 
 skip $isroot "Root access is needed. Skipping all tests." "$NUM_TESTS" && exit 0
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 0
+fi
 
 system_has_ns=0
 if [ -d "/proc/$$/ns" ]; then

--- a/tests/regression/kernel/test_ns_contexts_change
+++ b/tests/regression/kernel/test_ns_contexts_change
@@ -170,6 +170,10 @@ fi
 
 skip $isroot "Root access is needed. Skipping all tests." "$NUM_TESTS" && exit 0
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
 
 system_has_ns=0
 if [ -d "/proc/$$/ns" ]; then

--- a/tests/regression/kernel/test_rotation_destroy_flush
+++ b/tests/regression/kernel/test_rotation_destroy_flush
@@ -126,6 +126,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+	skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+	exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_select_poll_epoll
+++ b/tests/regression/kernel/test_select_poll_epoll
@@ -371,6 +371,11 @@ fi
 
 diag "Supported syscalls are $SUPPORTED_SYSCALLS_LIST"
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_syscall
+++ b/tests/regression/kernel/test_syscall
@@ -670,6 +670,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_userspace_probe
+++ b/tests/regression/kernel/test_userspace_probe
@@ -821,6 +821,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/tools/clear/test_kernel
+++ b/tests/regression/tools/clear/test_kernel
@@ -565,6 +565,11 @@ snapshot_tests=(test_kernel_streaming_snapshot
 	test_kernel_local_snapshot
 )
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all kernel streaming tests." $NUM_TESTS ||
 {
 	trap signal_cleanup SIGTERM SIGINT

--- a/tests/regression/tools/filtering/test_valid_filter
+++ b/tests/regression/tools/filtering/test_valid_filter
@@ -1460,6 +1460,12 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_KERNEL_TESTS
+        stop_lttng_sessiond
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all kernel valid filter tests." $NUM_KERNEL_TESTS ||
 {
 	diag "Test kernel valid filters"

--- a/tests/regression/tools/health/test_thread_ok
+++ b/tests/regression/tools/health/test_thread_ok
@@ -67,6 +67,7 @@ function test_thread_ok
 	$CURDIR/$HEALTH_CHECK_BIN > ${STDOUT_PATH} 2> ${STDERR_PATH}
 	report_errors
 
+	skip $ist_skip "SKIP_KERNEL_TEST was enabled. Skipping kernel consumer health check test." "5" ||
 	skip $isroot "Root access is needed. Skipping kernel consumer health check test." "5" ||
 	{
 		diag "With kernel consumer daemon"
@@ -120,6 +121,12 @@ if [ "$(id -u)" == "0" ]; then
 	isroot=1
 else
 	isroot=0
+fi
+
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+	ist_skip=0
+else
+	ist_skip=1
 fi
 
 test_thread_ok

--- a/tests/regression/tools/live/test_kernel
+++ b/tests/regression/tools/live/test_kernel
@@ -39,6 +39,11 @@ function clean_live_tracing()
 	rm -rf $TRACE_PATH
 }
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+	plan_skip_all "SKIP_KERNEL_TEST was enabled. Skipping all tests."
+	exit 0
+fi
+
 # Need root access for kernel tracing.
 if [ "$(id -u)" == "0" ]; then
 	isroot=1

--- a/tests/regression/tools/live/test_lttng_kernel
+++ b/tests/regression/tools/live/test_lttng_kernel
@@ -51,6 +51,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	modprobe lttng-test

--- a/tests/regression/tools/metadata/test_kernel
+++ b/tests/regression/tools/metadata/test_kernel
@@ -104,6 +104,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all kernel metadata tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/tools/notification/test_notification_kernel_buffer_usage
+++ b/tests/regression/tools/notification/test_notification_kernel_buffer_usage
@@ -63,29 +63,38 @@ function test_buffer_usage_notification
 	wait $APP_PID 2> /dev/null
 }
 
-if [ "$(id -u)" == "0" ]; then
-
-	validate_lttng_modules_present
-
-
-	modprobe lttng-test
-
-	# Used on sessiond launch.
-	LTTNG_SESSIOND_ENV_VARS="LTTNG_TESTPOINT_ENABLE=1 \
-		CONSUMER_PAUSE_PIPE_PATH=${TESTPOINT_PIPE_PATH} \
-		LD_PRELOAD=${TESTPOINT}"
-	start_lttng_sessiond_notap
-
-	test_buffer_usage_notification
-
-	stop_lttng_sessiond_notap
-	rmmod lttng-test
-
-	rm -rf "${consumerd_pipe[@]}" 2> /dev/null
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skiptest=0
 else
-	# Kernel tests are skipped.
-	plan_tests $NUM_TESTS
-	skip 0 "Root access is needed. Skipping all kernel notification tests." $NUM_TESTS
+        skiptest=1
 fi
+
+skip $skiptest "SKIP_KERNEL_TEST was enabled. Skipping all tests." $NUM_TESTS ||
+{
+	if [ "$(id -u)" == "0" ]; then
+
+		validate_lttng_modules_present
+
+
+		modprobe lttng-test
+
+		# Used on sessiond launch.
+		LTTNG_SESSIOND_ENV_VARS="LTTNG_TESTPOINT_ENABLE=1 \
+			CONSUMER_PAUSE_PIPE_PATH=${TESTPOINT_PIPE_PATH} \
+			LD_PRELOAD=${TESTPOINT}"
+		start_lttng_sessiond_notap
+
+		test_buffer_usage_notification
+
+		stop_lttng_sessiond_notap
+		rmmod lttng-test
+
+		rm -rf "${consumerd_pipe[@]}" 2> /dev/null
+	else
+		# Kernel tests are skipped.
+		plan_tests $NUM_TESTS
+		skip 0 "Root access is needed. Skipping all kernel notification tests." $NUM_TESTS
+	fi
+}
 
 rm -rf "$TEST_TMPDIR"

--- a/tests/regression/tools/notification/test_notification_kernel_capture
+++ b/tests/regression/tools/notification/test_notification_kernel_capture
@@ -30,23 +30,31 @@ function test_basic_error_path
 	wait $APP_PID 2> /dev/null
 }
 
-
-if [ "$(id -u)" == "0" ]; then
-	validate_lttng_modules_present
-
-	modprobe lttng-test
-
-	start_lttng_sessiond_notap
-
-	test_basic_error_path
-
-	stop_lttng_sessiond_notap
-	rmmod lttng-test
-
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skiptest=0
 else
-	# Kernel tests are skipped.
-	plan_tests $NUM_TESTS
-	skip 0 "Root access is needed. Skipping all kernel notification tests." $NUM_TESTS
+        skiptest=1
 fi
+
+skip $skiptest "SKIP_KERNEL_TEST was enabled. Skipping all tests." $NUM_TESTS ||
+{
+	if [ "$(id -u)" == "0" ]; then
+		validate_lttng_modules_present
+
+		modprobe lttng-test
+
+		start_lttng_sessiond_notap
+
+		test_basic_error_path
+
+		stop_lttng_sessiond_notap
+		rmmod lttng-test
+
+	else
+		# Kernel tests are skipped.
+		plan_tests $NUM_TESTS
+		skip 0 "Root access is needed. Skipping all kernel notification tests." $NUM_TESTS
+	fi
+}
 
 rm -f "$TESTAPP_STATE_PATH"

--- a/tests/regression/tools/notification/test_notification_kernel_error
+++ b/tests/regression/tools/notification/test_notification_kernel_error
@@ -30,23 +30,31 @@ function test_basic_error_path
 	wait $APP_PID 2> /dev/null
 }
 
-
-if [ "$(id -u)" == "0" ]; then
-	validate_lttng_modules_present
-
-	modprobe lttng-test
-
-	start_lttng_sessiond_notap
-
-	test_basic_error_path
-
-	stop_lttng_sessiond_notap
-	rmmod lttng-test
-
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+	skiptest=0
 else
-	# Kernel tests are skipped.
-	plan_tests $NUM_TESTS
-	skip 0 "Root access is needed. Skipping all kernel notification tests." $NUM_TESTS
+	skiptest=1
 fi
+
+skip $skiptest "SKIP_KERNEL_TEST was enabled. Skipping all tests." $NUM_TESTS ||
+{
+	if [ "$(id -u)" == "0" ]; then
+		validate_lttng_modules_present
+
+		modprobe lttng-test
+
+		start_lttng_sessiond_notap
+
+		test_basic_error_path
+
+		stop_lttng_sessiond_notap
+		rmmod lttng-test
+
+	else
+		# Kernel tests are skipped.
+		plan_tests $NUM_TESTS
+		skip 0 "Root access is needed. Skipping all kernel notification tests." $NUM_TESTS
+	fi
+}
 
 rm -f "$TESTAPP_STATE_PATH"

--- a/tests/regression/tools/notification/test_notification_kernel_instrumentation
+++ b/tests/regression/tools/notification/test_notification_kernel_instrumentation
@@ -28,22 +28,31 @@ function test_kernel_instrumentation_notification
 	wait $APP_PID 2> /dev/null
 }
 
-if [ "$(id -u)" == "0" ]; then
-	validate_lttng_modules_present
-
-	modprobe lttng-test
-
-	start_lttng_sessiond_notap
-
-	test_kernel_instrumentation_notification
-
-	stop_lttng_sessiond_notap
-	rmmod lttng-test
-
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skiptest=0
 else
-	# Kernel tests are skipped.
-	plan_tests $NUM_TESTS
-	skip 0 "Root access is needed. Skipping all kernel notification tests." $NUM_TESTS
+        skiptest=1
 fi
+
+skip $skiptest "SKIP_KERNEL_TEST was enabled. Skipping all tests." $NUM_TESTS ||
+{
+	if [ "$(id -u)" == "0" ]; then
+		validate_lttng_modules_present
+
+		modprobe lttng-test
+
+		start_lttng_sessiond_notap
+
+		test_kernel_instrumentation_notification
+
+		stop_lttng_sessiond_notap
+		rmmod lttng-test
+
+	else
+		# Kernel tests are skipped.
+		plan_tests $NUM_TESTS
+		skip 0 "Root access is needed. Skipping all kernel notification tests." $NUM_TESTS
+	fi
+}
 
 rm -f "$TESTAPP_STATE_PATH"

--- a/tests/regression/tools/notification/test_notification_multi_app
+++ b/tests/regression/tools/notification/test_notification_multi_app
@@ -427,16 +427,24 @@ else
         skip 0 "Root access is needed. Skipping all kernel multi-app notification tests." $NUM_TEST_KERNEL
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skiptest=0
+else
+        skiptest=1
+fi
 
-for fct_test in ${TESTS[@]};
-do
-	TRACE_PATH=$(mktemp -d -t tmp.test_notification_multi_app_trace_path.XXXXXX)
+skip $skiptest "SKIP_KERNEL_TEST was enabled. Skipping all tests." $NUM_TEST_KERNEL ||
+{
+	for fct_test in ${TESTS[@]};
+	do
+		TRACE_PATH=$(mktemp -d -t tmp.test_notification_multi_app_trace_path.XXXXXX)
 
-	${fct_test}
-	if [ $? -ne 0 ]; then
-		break;
-	fi
+		${fct_test}
+		if [ $? -ne 0 ]; then
+			break;
+		fi
 
-	# Only delete if successful
-	rm -rf $TRACE_PATH
-done
+		# Only delete if successful
+		rm -rf $TRACE_PATH
+	done
+}

--- a/tests/regression/tools/notification/test_notification_notifier_discarded_count
+++ b/tests/regression/tools/notification/test_notification_notifier_discarded_count
@@ -394,6 +394,11 @@ function test_ust_notifier_discarded_regardless_trigger_owner
 test_ust_notifier_discarded_count
 test_ust_notifier_discarded_count_max_bucket
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $KERNEL_NUM_TESTS
+        exit 1
+fi
+
 if [ "$(id -u)" == "0" ]; then
 
 	validate_lttng_modules_present

--- a/tests/regression/tools/regen-metadata/test_kernel
+++ b/tests/regression/tools/regen-metadata/test_kernel
@@ -105,6 +105,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all kernel streaming tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/tools/regen-statedump/test_kernel
+++ b/tests/regression/tools/regen-statedump/test_kernel
@@ -45,6 +45,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all kernel streaming tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/tools/rotation/test_kernel
+++ b/tests/regression/tools/rotation/test_kernel
@@ -113,6 +113,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all kernel streaming tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/tools/snapshots/test_kernel
+++ b/tests/regression/tools/snapshots/test_kernel
@@ -228,6 +228,11 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all kernel snapshot tests" $NUM_TESTS ||
 {
 

--- a/tests/regression/tools/tracker/test_event_tracker
+++ b/tests/regression/tools/tracker/test_event_tracker
@@ -474,6 +474,12 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_KERNEL_TESTS
+        stop_lttng_sessiond
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all kernel tracker tests." $NUM_KERNEL_TESTS ||
 {
 	diag "Test kernel tracker"

--- a/tests/regression/tools/trigger/test_add_trigger_cli
+++ b/tests/regression/tools/trigger/test_add_trigger_cli
@@ -40,6 +40,12 @@ else
 	ist_root=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        ist_skip=0
+else
+        ist_skip=1
+fi
+
 function test_success ()
 {
 	local test_name="$1"
@@ -223,6 +229,7 @@ test_success "--exclude-name two" "trigger5" \
 	--condition event-rule-matches --type=user --name='jean-*' --exclude-name jean-chretien -x jean-charest \
 	--action notify
 
+skip $ist_skip "SKIP_KERNEL_TEST: skipping kprobe tests" 18 ||
 skip $ist_root "non-root user: skipping kprobe tests" 18 || {
 	i=0
 
@@ -262,6 +269,7 @@ skip $ist_root "non-root user: skipping kprobe tests" 18 || {
 	done
 }
 
+skip $ist_skip "SKIP_KERNEL_TEST: skipping uprobe tests" 6 ||
 skip $ist_root "non-root user: skipping uprobe tests" 6 || {
 	test_success "--condition event-rule-matches uprobe" "uprobe-trigger-0" \
 		--name="uprobe-trigger-0" \
@@ -274,6 +282,7 @@ skip $ist_root "non-root user: skipping uprobe tests" 6 || {
 		--action notify
 }
 
+skip $ist_skip "SKIP_KERNEL_TEST: skipping syscall tests" 30 ||
 skip $ist_root "non-root user: skipping syscall tests" 30 || {
 	test_success "--condition event-rule-matches one syscall" "syscall-trigger-0" \
 		--name="syscall-trigger-0" \

--- a/tests/regression/tools/trigger/test_list_triggers_cli
+++ b/tests/regression/tools/trigger/test_list_triggers_cli
@@ -51,7 +51,6 @@ else
 	hast_sdt_binary=0
 fi
 
-
 test_top_level_options ()
 {
 	diag "Listing top level options"
@@ -2689,6 +2688,11 @@ test_notify_action ()
 }
 
 plan_tests $NUM_TESTS
+
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 0
+fi
 
 # shellcheck disable=SC2119
 start_lttng_sessiond_notap

--- a/tests/regression/tools/wildcard/test_event_wildcard
+++ b/tests/regression/tools/wildcard/test_event_wildcard
@@ -132,6 +132,12 @@ else
 	isroot=0
 fi
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_KERNEL_TESTS
+        stop_lttng_sessiond
+        exit 1
+fi
+
 skip $isroot "Root access is needed. Skipping all kernel wildcard tests." $NUM_KERNEL_TESTS ||
 {
 	diag "Test kernel wildcards"

--- a/tests/regression/ust/rotation-destroy-flush/test_rotation_destroy_flush
+++ b/tests/regression/ust/rotation-destroy-flush/test_rotation_destroy_flush
@@ -126,6 +126,11 @@ TESTS=(
 TEST_COUNT=${#TESTS[@]}
 i=0
 
+if [ "$SKIP_KERNEL_TEST" == "1" ]; then
+        skip 0 "SKIP_KERNEL_TEST was enabled, skipping." $NUM_TESTS
+        exit 1
+fi
+
 while [ "$i" -lt "$TEST_COUNT" ]; do
 
 	trap signal_cleanup SIGTERM SIGINT


### PR DESCRIPTION
The current tests will run both userspace and kernel testing. Some of use cases only use lttng for one kind of tracing on an embedded device (e.g. userspace) If the lttng modules(.ko files) is not present during the test, it would end up with lots of failing.

This commit separate the tests by allowing a flag to be passed and marked the kernel related tests as SKIP instead of FAIL if the modules is not presented.

e.g. before running the tests with make, add a flag to environment like "export SKIP_KERNEL_TEST=1" the test cases would skip kernel test.

Tested with this commit under a local setup, the result as below:

====================================================
   lttng-tools 2.13.11: tests/unit/test-suite.log
====================================================

 TOTAL: 1032
 PASS:  1032
 SKIP:  0
 XFAIL: 0
 FAIL:  0
 XPASS: 0
 ERROR: 0

.. contents:: :depth: 2

==========================================================
   lttng-tools 2.13.11: tests/regression/test-suite.log
==========================================================

 TOTAL: 11091
 PASS:  7243
 SKIP:  3848
 XFAIL: 0
 FAIL:  0
 XPASS: 0
 ERROR: 0

.. contents:: :depth: 2

PASS: tools/filtering/test_valid_filter
=======================================