### PR TITLE
tests: Add LTTNG_TOOLS_DISABLE_KERNEL_TESTS flags to skip kernel test

### DIFF
--- a/tests/destructive/metadata-regeneration
+++ b/tests/destructive/metadata-regeneration
@@ -202,6 +202,9 @@ if ! destructive_tests_enabled ; then
 	exit 0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	original_date=$(date)

--- a/tests/perf/test_perf_raw.in
+++ b/tests/perf/test_perf_raw.in
@@ -154,6 +154,9 @@ have_libpfm
 
 test_ust_raw
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." 9 ||
 skip $isroot "Root access is needed for kernel testing, skipping." 9 ||
 {
 	modprobe lttng-test

--- a/tests/regression/kernel/test_all_events
+++ b/tests/regression/kernel/test_all_events
@@ -49,6 +49,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_callstack
+++ b/tests/regression/kernel/test_callstack
@@ -142,6 +142,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." "$NUM_TESTS" ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_channel
+++ b/tests/regression/kernel/test_channel
@@ -53,6 +53,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	start_lttng_sessiond

--- a/tests/regression/kernel/test_clock_override
+++ b/tests/regression/kernel/test_clock_override
@@ -180,6 +180,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_event_basic
+++ b/tests/regression/kernel/test_event_basic
@@ -79,6 +79,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_kernel_function
+++ b/tests/regression/kernel/test_kernel_function
@@ -49,6 +49,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	start_lttng_sessiond_notap

--- a/tests/regression/kernel/test_lttng_logger
+++ b/tests/regression/kernel/test_lttng_logger
@@ -116,6 +116,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_ns_contexts
+++ b/tests/regression/kernel/test_ns_contexts
@@ -113,6 +113,9 @@ if [ "$(id -u)" == "0" ]; then
 	isroot=1
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." "$NUM_TESTS" && exit 0
 
 

--- a/tests/regression/kernel/test_ns_contexts_change
+++ b/tests/regression/kernel/test_ns_contexts_change
@@ -168,6 +168,9 @@ if [ "$(id -u)" == "0" ]; then
 	isroot=1
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." "$NUM_TESTS" && exit 0
 
 

--- a/tests/regression/kernel/test_rotation_destroy_flush
+++ b/tests/regression/kernel/test_rotation_destroy_flush
@@ -126,6 +126,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_select_poll_epoll
+++ b/tests/regression/kernel/test_select_poll_epoll
@@ -371,6 +371,9 @@ fi
 
 diag "Supported syscalls are $SUPPORTED_SYSCALLS_LIST"
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_syscall
+++ b/tests/regression/kernel/test_syscall
@@ -670,6 +670,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/kernel/test_userspace_probe
+++ b/tests/regression/kernel/test_userspace_probe
@@ -821,6 +821,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/tools/clear/test_kernel
+++ b/tests/regression/tools/clear/test_kernel
@@ -565,6 +565,9 @@ snapshot_tests=(test_kernel_streaming_snapshot
 	test_kernel_local_snapshot
 )
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all kernel streaming tests." $NUM_TESTS ||
 {
 	trap signal_cleanup SIGTERM SIGINT

--- a/tests/regression/tools/filtering/test_valid_filter
+++ b/tests/regression/tools/filtering/test_valid_filter
@@ -1460,6 +1460,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_KERNEL_TESTS ||
 skip $isroot "Root access is needed. Skipping all kernel valid filter tests." $NUM_KERNEL_TESTS ||
 {
 	diag "Test kernel valid filters"

--- a/tests/regression/tools/health/test_thread_ok
+++ b/tests/regression/tools/health/test_thread_ok
@@ -122,6 +122,8 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 test_thread_ok
 
 rm -rf ${HEALTH_PATH}

--- a/tests/regression/tools/live/test_kernel
+++ b/tests/regression/tools/live/test_kernel
@@ -47,6 +47,14 @@ else
 	exit 0
 fi
 
+check_skip_kernel_test
+
+if [ $? == 0 ]; then
+	plan_skip_all "LTTng modules not detected. Skipping all tests."
+	exit 0
+fi
+
+
 modprobe lttng-test
 
 start_lttng_sessiond_notap

--- a/tests/regression/tools/live/test_lttng_kernel
+++ b/tests/regression/tools/live/test_lttng_kernel
@@ -51,6 +51,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all tests." $NUM_TESTS ||
 {
 	modprobe lttng-test

--- a/tests/regression/tools/metadata/test_kernel
+++ b/tests/regression/tools/metadata/test_kernel
@@ -104,6 +104,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all kernel metadata tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/tools/notification/test_notification_kernel_buffer_usage
+++ b/tests/regression/tools/notification/test_notification_kernel_buffer_usage
@@ -63,7 +63,16 @@ function test_buffer_usage_notification
 	wait $APP_PID 2> /dev/null
 }
 
+check_skip_kernel_test
+ismodready=$?
+
 if [ "$(id -u)" == "0" ]; then
+
+	if [ $ismodready == 0 ];then
+		plan_tests $NUM_TESTS
+		skip 0 "LTTng modules not detected. Skipping all tests." $NUM_TESTS
+		exit 0
+	fi
 
 	validate_lttng_modules_present
 

--- a/tests/regression/tools/notification/test_notification_kernel_capture
+++ b/tests/regression/tools/notification/test_notification_kernel_capture
@@ -30,8 +30,16 @@ function test_basic_error_path
 	wait $APP_PID 2> /dev/null
 }
 
+check_skip_kernel_test
+ismodready=$?
 
 if [ "$(id -u)" == "0" ]; then
+	if [ $ismodready == 0 ];then
+		plan_tests $NUM_TESTS
+		skip 0 "LTTng modules not detected. Skipping all tests." $NUM_TESTS
+		exit 0
+	fi
+
 	validate_lttng_modules_present
 
 	modprobe lttng-test

--- a/tests/regression/tools/notification/test_notification_kernel_error
+++ b/tests/regression/tools/notification/test_notification_kernel_error
@@ -30,8 +30,16 @@ function test_basic_error_path
 	wait $APP_PID 2> /dev/null
 }
 
+check_skip_kernel_test
+ismodready=$?
 
 if [ "$(id -u)" == "0" ]; then
+	if [ $ismodready == 0 ]; then
+		plan_tests $NUM_TESTS
+		skip 0 "LTTng modules not detected. Skipping all tests." $NUM_TESTS
+		exit 0
+	fi
+
 	validate_lttng_modules_present
 
 	modprobe lttng-test

--- a/tests/regression/tools/notification/test_notification_kernel_instrumentation
+++ b/tests/regression/tools/notification/test_notification_kernel_instrumentation
@@ -28,7 +28,16 @@ function test_kernel_instrumentation_notification
 	wait $APP_PID 2> /dev/null
 }
 
+check_skip_kernel_test
+ismodready=$?
+
 if [ "$(id -u)" == "0" ]; then
+	if [ $ismodready == 0 ]; then
+		plan_tests $NUM_TESTS
+		skip 0 "LTTng modules not detected. Skipping all tests." $NUM_TESTS
+		exit 0
+	fi
+
 	validate_lttng_modules_present
 
 	modprobe lttng-test

--- a/tests/regression/tools/notification/test_notification_multi_app
+++ b/tests/regression/tools/notification/test_notification_multi_app
@@ -417,7 +417,14 @@ TESTS=(
 	test_on_register_evaluation_ust
 )
 
+check_skip_kernel_test
+ismodready=$?
+
 if [ "$(id -u)" == "0" ]; then
+	if [ ismodready == 0 ]; then
+		skip 0 "LTTng modules not detected. Skipping all tests." $NUM_TEST_KERNEL
+		exit 0
+	fi
 	validate_lttng_modules_present
 	TESTS+=(
 	test_multi_app_kernel

--- a/tests/regression/tools/notification/test_notification_notifier_discarded_count
+++ b/tests/regression/tools/notification/test_notification_notifier_discarded_count
@@ -393,8 +393,15 @@ function test_ust_notifier_discarded_regardless_trigger_owner
 
 test_ust_notifier_discarded_count
 test_ust_notifier_discarded_count_max_bucket
+check_skip_kernel_test
+ismodready=$?
 
 if [ "$(id -u)" == "0" ]; then
+
+	if [ $ismodready == 0 ]; then
+		skip 0 "LTTng modules not detected. Skipping all tests." $KERNEL_NUM_TESTS
+		exit 1
+	fi
 
 	validate_lttng_modules_present
 

--- a/tests/regression/tools/regen-metadata/test_kernel
+++ b/tests/regression/tools/regen-metadata/test_kernel
@@ -105,6 +105,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all kernel streaming tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/tools/regen-statedump/test_kernel
+++ b/tests/regression/tools/regen-statedump/test_kernel
@@ -45,6 +45,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all kernel streaming tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/tools/rotation/test_kernel
+++ b/tests/regression/tools/rotation/test_kernel
@@ -113,6 +113,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all kernel streaming tests." $NUM_TESTS ||
 {
 	validate_lttng_modules_present

--- a/tests/regression/tools/snapshots/test_kernel
+++ b/tests/regression/tools/snapshots/test_kernel
@@ -228,6 +228,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_TESTS ||
 skip $isroot "Root access is needed. Skipping all kernel snapshot tests" $NUM_TESTS ||
 {
 

--- a/tests/regression/tools/tracker/test_event_tracker
+++ b/tests/regression/tools/tracker/test_event_tracker
@@ -474,6 +474,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_KERNEL_TESTS ||
 skip $isroot "Root access is needed. Skipping all kernel tracker tests." $NUM_KERNEL_TESTS ||
 {
 	diag "Test kernel tracker"

--- a/tests/regression/tools/trigger/test_add_trigger_cli
+++ b/tests/regression/tools/trigger/test_add_trigger_cli
@@ -223,6 +223,7 @@ test_success "--exclude-name two" "trigger5" \
 	--condition event-rule-matches --type=user --name='jean-*' --exclude-name jean-chretien -x jean-charest \
 	--action notify
 
+skip check_skip_kernel_test "LTTng modules not detected. Skipping all tests." 18 ||
 skip $ist_root "non-root user: skipping kprobe tests" 18 || {
 	i=0
 
@@ -262,6 +263,7 @@ skip $ist_root "non-root user: skipping kprobe tests" 18 || {
 	done
 }
 
+skip check_skip_kernel_test "LTTng modules not detected. Skipping all tests." 6 ||
 skip $ist_root "non-root user: skipping uprobe tests" 6 || {
 	test_success "--condition event-rule-matches uprobe" "uprobe-trigger-0" \
 		--name="uprobe-trigger-0" \
@@ -274,6 +276,7 @@ skip $ist_root "non-root user: skipping uprobe tests" 6 || {
 		--action notify
 }
 
+skip check_skip_kernel_test "LTTng modules not detected. Skipping all tests." 30 ||
 skip $ist_root "non-root user: skipping syscall tests" 30 || {
 	test_success "--condition event-rule-matches one syscall" "syscall-trigger-0" \
 		--name="syscall-trigger-0" \

--- a/tests/regression/tools/trigger/test_list_triggers_cli
+++ b/tests/regression/tools/trigger/test_list_triggers_cli
@@ -2689,15 +2689,21 @@ test_notify_action ()
 }
 
 plan_tests $NUM_TESTS
+check_skip_kernel_test
+ismodready=$?
 
 # shellcheck disable=SC2119
 start_lttng_sessiond_notap
 
 test_top_level_options
 test_event_rule_matches_tracepoint
+skip $ismodready "LTTng modules not detected. Skipping all tests." 13 ||
 skip $ist_root "non-root user: skipping kprobe tests" 13 || test_event_rule_matches_probe
+skip $ismodready "LTTng modules not detected. Skipping all tests." 9 ||
 skip $ist_root "non-root user: skipping uprobe tests" 9 || test_event_rule_matches_userspace_probe_elf
+skip $ismodready "LTTng modules not detected. Skipping all tests." 9 ||
 skip $(($ist_root && $hast_sdt_binary)) "skipping userspace probe SDT tests" 9 || test_event_rule_matches_userspace_probe_sdt
+skip $ismodready "LTTng modules not detected. Skipping all tests." 17 ||
 skip $ist_root "non-root user: skipping syscall tests" 17 || test_event_rule_matches_syscall
 test_session_consumed_size_condition
 test_buffer_usage_conditions

--- a/tests/regression/tools/wildcard/test_event_wildcard
+++ b/tests/regression/tools/wildcard/test_event_wildcard
@@ -132,6 +132,9 @@ else
 	isroot=0
 fi
 
+check_skip_kernel_test
+
+skip $? "LTTng modules not detected. Skipping all tests." $NUM_KERNEL_TESTS ||
 skip $isroot "Root access is needed. Skipping all kernel wildcard tests." $NUM_KERNEL_TESTS ||
 {
 	diag "Test kernel wildcards"

--- a/tests/regression/ust/rotation-destroy-flush/test_rotation_destroy_flush
+++ b/tests/regression/ust/rotation-destroy-flush/test_rotation_destroy_flush
@@ -117,6 +117,13 @@ function test_rotation_destroy_flush()
 
 plan_tests $NUM_TESTS
 
+check_skip_kernel_test
+
+if [ $? == 0 ]; then
+	skip 0 "LTTng modules not detected. Skipping all tests." $NUM_TESTS
+	exit 0
+fi
+
 print_test_banner "$TEST_DESC"
 
 TESTS=(

--- a/tests/utils/utils.sh
+++ b/tests/utils/utils.sh
@@ -323,6 +323,17 @@ function conf_proc_count()
 	echo
 }
 
+# Return 0 if disable kernel test was set
+function check_skip_kernel_test ()
+{
+	# Check for skip test kernel flag
+	if [ $LTTNG_TOOLS_DISABLE_KERNEL_TESTS == 1 ]; then
+		return 0
+	fi
+
+	return 1
+}
+
 # Check if base lttng-modules are present.
 # Bail out on failure
 function validate_lttng_modules_present ()


### PR DESCRIPTION
The current tests will run both userspace and kernel testing. Some of use cases only use lttng for one kind of tracing on an embedded device (e.g. userspace), so in this scenario, the kernel modules might not install to target rootfs, the test cases would be fail and exit.

Add LTTNG_TOOLS_DISABLE_KERNEL_TESTS to skip the lttng kernel features test, this flag can be set via "make":

make check LTTNG_TOOLS_DISABLE_KERNEL_TESTS=1

When this flag was set, all kernel related testcases would be marked as SKIP in result.