### PR TITLE
common: Autodetect musl libc and fix C++ compilation errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,6 +181,13 @@ AM_CONDITIONAL([HAVE_SHELLCHECK], [test "x$SHELLCHECK" != "x"])
 AS_IF([test -f "$srcdir/bootstrap"], [in_git_repo=yes], [in_git_repo=no])
 AM_CONDITIONAL([IN_GIT_REPO], [test "x$in_git_repo" = "xyes"])
 
+# Check for musl libc:
+case "${host_cpu}-${host_os}-${LIBC}" in
+  *-musl*)
+    AC_DEFINE([HAVE_MUSL_LIBC], [1], [Define to 1 if building against musl libc.])
+    ;;
+esac
+
 # check for bison
 AC_PROG_YACC
 BISON=$YACC

--- a/src/common/poller.cpp
+++ b/src/common/poller.cpp
@@ -7,6 +7,10 @@
 #include <common/error.hpp>
 #include <common/poller.hpp>
 
+#if defined(HAVE_MUSL_LIBC) && !defined(LTTNG_MUSL_EPOLL_CLOEXEC_REPLACEMENT)
+constexpr int LTTNG_MUSL_EPOLL_CLOEXEC_REPLACEMENT = EPOLL_CLOEXEC;
+#endif
+
 namespace {
 
 std::uint32_t to_epoll_events(lttng::poller::event_type events)
@@ -58,7 +62,11 @@ lttng::poller::event_type from_epoll_events(std::uint32_t epoll_events)
 
 lttng::poller::poller() :
 	_epoll_fd([]() {
+#if defined(HAVE_MUSL_LIBC)
+		const auto epoll_fd = ::epoll_create1(LTTNG_MUSL_EPOLL_CLOEXEC_REPLACEMENT);
+#else
 		const auto epoll_fd = ::epoll_create1(::EPOLL_CLOEXEC);
+#endif
 
 		if (epoll_fd < 0) {
 			LTTNG_THROW_POSIX("Failed to create epoll fd", errno);

--- a/src/common/timerfd.hpp
+++ b/src/common/timerfd.hpp
@@ -14,12 +14,22 @@
 #include <sys/timerfd.h>
 #include <time.h>
 
+#if defined(HAVE_MUSL_LIBC) && !defined(LTTNG_MUSL_TFD_CLOEXEC_REPLACEMENT)
+constexpr int LTTNG_MUSL_TFD_CLOEXEC_REPLACEMENT = TFD_CLOEXEC;
+#endif
+
 namespace lttng {
 
 class timerfd : public stream_descriptor {
 public:
 	/* Throws a posix_error exception on failure to create the underlying resource. */
-	explicit timerfd(int flags = ::TFD_CLOEXEC);
+	explicit timerfd(int flags =
+#if defined(HAVE_MUSL_LIBC)
+		LTTNG_MUSL_TFD_CLOEXEC_REPLACEMENT
+#else
+		::TFD_CLOEXEC
+#endif
+	);
 	timerfd(const timerfd&) = delete;
 	timerfd& operator=(const timerfd&) = delete;
 	timerfd(timerfd&&) = delete;


### PR DESCRIPTION
This patch addresses C++ compilation failures of lttng-tools (version 2.15.0) when built against musl libc. This issue arises due to a strict interpretation by C++ compilers (especially under musl) regarding the use of preprocessor macros as default function parameters or direct function arguments.

|                  from /lttng-tools-2.15.0/src/common/poller.hpp:19,
|                  from /lttng-tools-2.15.0/src/common/poller.cpp:8:
|/lttng-tools-2.15.0/src/common/poller.cpp: In lambda function:
| /lttng-tools-2.15.0/src/common/poller.cpp:61:57: error: expected id-expression before numeric constant
|    61 |                 const auto epoll_fd = ::epoll_create1(::EPOLL_CLOEXEC);
|       |                                                         ^~~~~~~~~~~~~
......
|                  from s/lttng-tools-2.15.0/src/common/timerfd.hpp:14,
|                  from s/lttng-tools-2.15.0/src/common/timerfd.cpp:10:
| /lttng-tools-2.15.0/src/common/timerfd.hpp:22:40: error: expected id-expression before numeric constant
|    22 |         explicit timerfd(int flags = ::TFD_CLOEXEC);
|       |                                        ^~~~~~~~~~~
